### PR TITLE
Fix double-dash in bottle filenames breaking brew upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,16 +88,23 @@ jobs:
             --root-url="https://github.com/${REPO}/releases/download/${TAG}" \
             local/caucus/caucus
 
+      - name: Rename bottle to single-dash filename
+        run: |
+          cd "$RUNNER_TEMP"
+          for f in caucus--*.tar.gz; do
+            mv "$f" "${f/caucus--/caucus-}"
+          done
+
       - name: Upload bottle to release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BOTTLE=$(ls "${RUNNER_TEMP}"/caucus--*.tar.gz)
+          BOTTLE=$(ls "${RUNNER_TEMP}"/caucus-*.tar.gz)
           gh release upload "$TAG" "$BOTTLE" --clobber
 
       - name: Save bottle SHA256
         run: |
-          BOTTLE=$(ls "${RUNNER_TEMP}"/caucus--*.tar.gz)
+          BOTTLE=$(ls "${RUNNER_TEMP}"/caucus-*.tar.gz)
           SHA=$(shasum -a 256 "$BOTTLE" | awk '{print $1}')
           mkdir -p bottle-sha
           echo "$SHA" > "bottle-sha/${{ matrix.bottle_tag }}"


### PR DESCRIPTION
brew bottle outputs files with double dashes (caucus--0.2.2...) but
Homebrew constructs download URLs with single dashes (caucus-0.2.2...).
Rename bottles after packaging to match the expected URL format.

Fixes #2

https://claude.ai/code/session_01V3vGmPh2wc9vLZos5U6eGN