### PR TITLE
Add utility-backed councils and adjudicated review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ name = "caucus-cli"
 version = "1.0.7"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "caucus-core",
  "clap",
@@ -173,7 +174,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -184,10 +184,13 @@ version = "1.0.7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tracing",
 ]
 
@@ -197,6 +200,7 @@ version = "1.0.7"
 dependencies = [
  "caucus-core",
  "pyo3",
+ "pyo3-build-config",
  "serde",
  "serde_json",
  "tokio",
@@ -297,6 +301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,12 +332,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -335,6 +361,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
@@ -348,8 +408,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -380,6 +445,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -594,6 +665,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1155,6 +1236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1449,47 @@ dependencies = [
  "rustls",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1789,6 +1920,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/README.md
+++ b/README.md
@@ -31,27 +31,33 @@ Then: `from caucus import consensus, Candidate`
 
 ## Quick start
 
+Already signed in to one of the supported CLIs? You do not need API keys.
+
 ```bash
-# Set API keys (or put them in .env)
-export OPENAI_API_KEY=sk-...
-export ANTHROPIC_API_KEY=sk-ant-...
-export GOOGLE_API_KEY=AI...
-export XAI_API_KEY=xai-...
+# See what is installed and ready
+caucus doctor
 
-# Just ask. Queries all configured models, synthesizes the best answer.
-caucus "What causes inflation?"
+# Build a council from ready CLIs and local models
+caucus ask --auto "What causes inflation?"
 
-# Pick your models
-caucus "What causes inflation?" -m gpt-5.2,claude-opus-4-6,gemini-3.1-pro-preview
+# Or use the built-in frontier profile
+caucus ask --profile deep "What causes inflation?"
 
-# See what's happening under the hood
-caucus "What causes inflation?" -v
-
-# Override strategy and format
-caucus "What causes inflation?" -s debate -f supreme-court
+# Show the members and the final reasoning
+caucus ask --profile deep --verbose --format detailed "What causes inflation?"
 ```
 
-No subcommand needed. caucus auto-detects configured models, uses `judge` strategy by default, and prints just the answer.
+Direct API models still work:
+
+```bash
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
+
+caucus "What causes inflation?" -m gpt-5.2,claude-opus-4-6
+```
+
+For the direct API form, `ask` is optional. caucus detects configured API
+models, uses `judge`, and prints the answer.
 
 ## Strategies
 
@@ -81,14 +87,108 @@ See also: [verbose output](examples/verbose.md), [debate with supreme-court form
 ```bash
 caucus "prompt"
 caucus ask "prompt" --strategy debate --format supreme-court
+caucus ask "prompt" --profile deep          # council profile (exact members)
+caucus ask "prompt" --auto                  # ready subscription CLIs + local models
+caucus review --git-diff                    # adjudicated multi-model code review
 caucus compare "prompt" --strategies majority-vote,judge
 caucus debate "prompt" --rounds 3
 caucus bench tests.jsonl -o results.json
+caucus profiles                             # list built-in and user profiles
+caucus doctor                               # adapter readiness + config health
 caucus serve --port 8080
 caucus serve --mcp
 ```
 
+## Councils and profiles
+
+A **council** is a named panel of exact member specs (`utility:model@effort`).
+`ask` and `review` accept `--profile NAME` (defaulting to the configured
+`default_profile`, then the built-in `deep`) or `--auto`, which assembles a
+zero-key council from locally discovered CLI adapters and local servers. No
+API keys required, and every exclusion is reported with its reason.
+
+The built-in `deep` profile (quorum 3, whole-run deadline 600s, judge strategy) has
+exactly these members:
+
+```
+claude:opus@xhigh
+claude:claude-fable-5@xhigh
+codex:default@xhigh
+opencode:zai-coding-plan/glm-5.2@xhigh
+kimi:kimi-code/k3@high
+```
+
+Adapter compatibility labels, shown by `caucus doctor`:
+
+| Label | Adapters | Meaning |
+|-------|----------|---------|
+| `stable` | claude, codex, ollama, lmstudio | Supported, expected to work |
+| `experimental` | kimi, opencode, gemini, grok, acp | Works, but flags/pins may shift |
+
+```bash
+caucus doctor          # readiness, config validity, profile health (or --json)
+caucus profiles        # all profiles with resolved members (or a name, or --json)
+```
+
+Kimi effort is set for each child process with
+`KIMI_MODEL_THINKING_EFFORT`; caucus does not edit Kimi's config. Grok Build
+accepts `low`, `medium`, and `high` only, so its strongest profile spec is
+`grok:grok-4.5@high`.
+
+## Adjudicated review
+
+`caucus review` is a fixed four-phase review pipeline (not a generic DAG):
+
+1. **Review:** each member independently reviews the input and returns
+   findings under a strict JSON schema (direct or fenced JSON only; prose is
+   never accepted as findings).
+2. **Anonymize:** findings get deterministic anonymous source IDs.
+3. **Vote:** blind peer support/oppose/abstain votes with evidence-linked
+   reasons over all anonymized findings.
+4. **Adjudicate:** a council judge accepts or rejects each finding and cites
+   the evidence and raw votes.
+
+Accepted findings are classified `unanimous`, `majority`, or `disputed` from
+the raw votes. Partial peer failures are warnings; review and voting require
+quorum. Adjudication uses the profile's judge. Bad model output never becomes
+a made-up vote or verdict.
+
+```bash
+caucus review --file src/main.rs              # exactly one input:
+caucus review --git-diff                      #   --file, --git-diff,
+caucus review --staged                        #   --staged, or stdin (default)
+git diff | caucus review
+caucus review --staged --profile deep --format json --output receipt.json
+# Start a checkpointed run
+caucus review --git-diff --manifest run.json
+
+# Resume it after an interruption
+caucus review --git-diff --manifest run.json --resume
+```
+
+The decision receipt is Markdown or JSON. It includes run and input hashes,
+member details, per-phase status, raw votes, and adjudication. Warnings plus
+deadline and request-count data are included too. See
+[examples/review-receipt.md](examples/review-receipt.md).
+
+Each completed review stage is checkpointed to a small versioned JSON file next
+to `--manifest` (or `.caucus-review.checkpoint.json`). `--resume` checks the
+input and options before reusing completed work.
+
+`--budget-usd` is **advisory only**: current transports expose no cost data,
+so it is recorded with a warning but not enforced. `--max-requests` is a hard
+cap across all phases, and it is cumulative across resumed invocations. The
+request count persists in the checkpoint, so a cap applies to the whole run,
+not to each `caucus review` invocation.
+
+Git input runs as explicit argv (`git diff [--staged]`). No shell involved.
+
 ## HTTP API
+
+The server binds to `127.0.0.1` by default and has no authentication. Do not
+expose it to a LAN or the internet. HTTP requests cannot run installed command
+or ACP adapters. Use the normal CLI commands for installed utilities. ACP is
+not implemented yet.
 
 ```bash
 caucus serve --port 8080
@@ -101,6 +201,11 @@ curl -X POST http://localhost:8080/v1/consensus \
     "format": "json"
   }'
 ```
+
+`/v1/consensus` also accepts `judge_model` for judge/debate strategies.
+`/v1/pipeline` runs configured pipeline steps over HTTP providers. `caucus
+serve --mcp` currently exposes majority and weighted consensus over supplied
+answers.
 
 ## Rust library
 
@@ -136,7 +241,8 @@ print(result.agreement_score)  # 0.67
 
 ## Claude Code Skill
 
-caucus includes a [skill](skill/SKILL.md) for Claude Code. Install it with [equip](https://github.com/bradleydwyer/equip):
+caucus includes a [skill](SKILL.md) for Claude Code. Install it with
+[equip](https://github.com/bradleydwyer/equip):
 
 ```bash
 equip install bradleydwyer/caucus
@@ -157,6 +263,66 @@ XAI_API_KEY=xai-...
 
 The CLI auto-loads `.env` from the current directory. You can also pass `--env path/to/.env`.
 
+**Credential handling:** caucus does not scrape credentials. Discovery checks
+PATH and local server ports. The Gemini adapter checks that `GEMINI_API_KEY`
+exists, but never reads or prints its value.
+
+Profile adapters use each CLI's existing login. `grok:` uses Grok Build;
+legacy `--models grok-*` uses the xAI API. Kimi effort is passed through the
+non-secret `KIMI_MODEL_THINKING_EFFORT` child environment variable.
+
+### Config file
+
+Profile and adapter config lives in TOML. Discovery order:
+`--config PATH`, then `./caucus.toml`, then
+`$XDG_CONFIG_HOME/caucus/config.toml`, then `~/.config/caucus/config.toml`.
+See [examples/config.toml](examples/config.toml) and
+[examples/caucus.toml](examples/caucus.toml).
+
+```toml
+default_profile = "deep"          # falls back to built-in `deep` when unset
+
+[profiles.frontier]               # user profiles shadow built-ins
+description = "..."
+strategy = "judge"                # strategy used by `ask`
+quorum = 3                        # default: member count
+deadline_secs = 600               # whole-run wall-clock limit
+request_timeout_secs = 240        # maximum for each provider request
+budget_usd = 5.0                  # advisory (see review docs)
+judge = "claude:opus@max"         # optional designated judge (default: first member)
+members = [
+  "claude:opus@xhigh",
+  "codex:default@xhigh",
+  "kimi:kimi-code/k3@high",
+  "grok:grok-4.5@high",
+]
+
+[adapters.claude]                 # per-adapter overrides
+binary_path = "/usr/local/bin/claude"
+timeout_secs = 900
+max_stdout_bytes = 2097152
+max_stderr_bytes = 262144
+env = { NO_COLOR = "1" }         # passed only to this adapter process
+
+[adapters.ollama]
+model = "llama3.2:latest"         # pin used by --auto when discovery finds none
+```
+
+Member specs are `utility:model@effort`; the model id is passed through
+verbatim. Effort support: claude `[low, medium, high, xhigh, max]`, codex
+`[minimal, low, medium, high, xhigh]`, kimi `[low, high, max]`, opencode all
+six, grok `[low, medium, high]`. No effort: ollama / lmstudio / gemini / acp.
+
+**Legacy profile fields:** the previous schema's `models`, `timeout_seconds`,
+and `deadline_seconds` keys are still accepted. They are migrated in memory
+only. Your file is never edited, and every migration prints a
+`config warning:` telling you exactly what changed: `models` becomes
+`members`, `timeout_seconds` becomes `request_timeout_secs`, and
+`deadline_seconds` becomes the whole-run `deadline_secs`. When both legacy
+fields are present, both limits are preserved.
+Legacy member strings work too: a pin-less entry like `codex@xhigh` means
+`codex:default@xhigh`, and the `glm` utility alias resolves to `opencode`.
+
 ## License
 
 MIT
@@ -164,12 +330,14 @@ MIT
 ## More Tools
 
 **Naming & Availability**
-- [available](https://github.com/bradleydwyer/available) — AI-powered project name finder (uses parked, staked & published)
-- [parked](https://github.com/bradleydwyer/parked) — Domain availability checker (DNS → WHOIS → RDAP)
-- [staked](https://github.com/bradleydwyer/staked) — Package registry name checker (npm, PyPI, crates.io + 19 more)
-- [published](https://github.com/bradleydwyer/published) — App store name checker (App Store & Google Play)
+
+- [available](https://github.com/bradleydwyer/available): AI-powered project name finder (uses parked, staked & published)
+- [parked](https://github.com/bradleydwyer/parked): Domain availability checker (DNS → WHOIS → RDAP)
+- [staked](https://github.com/bradleydwyer/staked): Package registry name checker (npm, PyPI, crates.io + 19 more)
+- [published](https://github.com/bradleydwyer/published): App store name checker (App Store & Google Play)
 
 **AI Tooling**
-- [sloppy](https://github.com/bradleydwyer/sloppy) — AI prose/slop detector
-- [nanaban](https://github.com/bradleydwyer/nanaban) — Gemini image generation CLI
-- [equip](https://github.com/bradleydwyer/equip) — Cross-agent skill manager
+
+- [sloppy](https://github.com/bradleydwyer/sloppy): AI prose/slop detector
+- [nanaban](https://github.com/bradleydwyer/nanaban): Gemini image generation CLI
+- [equip](https://github.com/bradleydwyer/equip): Cross-agent skill manager

--- a/SKILL.md
+++ b/SKILL.md
@@ -54,6 +54,8 @@ Always use `-f json` for parseable output.
 caucus "prompt" -f json                                          # all models, judge strategy
 caucus "prompt" -m gpt-5.2,claude-opus-4-6 -f json              # specific models
 caucus "prompt" -s debate -f json                                # debate strategy
+caucus "prompt" --profile deep -f json                           # council profile (exact members)
+caucus "prompt" --auto -f json                                   # zero-key council, no API keys
 caucus compare "prompt" --strategies majority-vote,judge -f json # compare strategies
 caucus "prompt" -v -f json                                       # verbose (individual responses)
 caucus "prompt" -f supreme-court                                 # dissent/concurrence format
@@ -62,6 +64,40 @@ caucus "prompt" -f supreme-court                                 # dissent/concu
 **Strategies:** `majority-vote`, `weighted-vote`, `judge` (default), `debate`, `debate-then-vote`
 
 **Output formats:** `plain` (default), `json`, `supreme-court`, `detailed`
+
+### 2a. Review Code or Diffs
+
+For adjudicated code/text review (independent reviews → anonymized blind peer
+votes → judged verdicts with a provenance receipt):
+
+```bash
+caucus review --file src/main.rs --format json      # one file
+caucus review --git-diff                            # working-tree diff
+caucus review --staged --profile deep               # staged diff, exact council
+git diff | caucus review --format json              # stdin
+caucus review --staged --manifest run.json --resume # checkpoint + resume
+```
+
+Receipts are Markdown (default) or JSON (`--format`), with deterministic run
+ids, raw votes/dissent, adjudications, and unanimous/majority/disputed
+classifications. `--max-requests` is a hard cap; `--budget-usd` is advisory.
+
+### 2b. Inspect Councils
+
+```bash
+caucus doctor          # adapter readiness + config health (--json available)
+caucus profiles        # list profiles and exact members (or a name / --json)
+```
+
+Adapters are labeled `stable` (claude, codex, ollama, lmstudio) or
+`experimental` (kimi, opencode, gemini, grok, acp). The built-in `deep`
+profile: `claude:opus@xhigh`, `claude:claude-fable-5@xhigh`,
+`codex:default@xhigh`, `opencode:zai-coding-plan/glm-5.2@xhigh`,
+`kimi:kimi-code/k3@high`.
+
+Profile `deadline_secs` is a whole-run wall-clock limit;
+`request_timeout_secs` bounds each provider request independently. Adapter
+`timeout_secs` can impose a stricter process limit.
 
 ### 3. Present Results
 

--- a/crates/caucus-cli/Cargo.toml
+++ b/crates/caucus-cli/Cargo.toml
@@ -15,10 +15,13 @@ tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
+async-trait.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 clap = { version = "4", features = ["derive"] }
 colored = "3"
 dotenvy = "0.15"
 axum = "0.8"
-tower-http = { version = "0.6", features = ["cors"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/caucus-cli/src/commands/ask.rs
+++ b/crates/caucus-cli/src/commands/ask.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
 use caucus_core::strategy::debate::DebateConfig;
 use caucus_core::{
     Candidate, ConsensusResult, ConsensusStrategy, MultiRoundDebate, OutputFormat, consensus,
@@ -5,7 +8,8 @@ use caucus_core::{
 use clap::Args;
 use colored::Colorize;
 
-use super::{build_single_provider, default_models};
+use super::run::RunDeadline;
+use super::{build_single_provider, council, default_models};
 
 #[derive(Args)]
 pub struct AskArgs {
@@ -13,8 +17,29 @@ pub struct AskArgs {
     pub prompt: String,
 
     /// Comma-separated list of models to query (defaults to all configured providers)
-    #[arg(short, long, value_delimiter = ',')]
+    #[arg(
+        short,
+        long,
+        value_delimiter = ',',
+        conflicts_with = "profile",
+        conflicts_with = "auto",
+        conflicts_with = "config"
+    )]
     pub models: Option<Vec<String>>,
+
+    /// Use a council profile's exact member specs instead of API models
+    #[arg(long, value_name = "NAME")]
+    pub profile: Option<String>,
+
+    /// Build a zero-key council from locally discovered adapters (ready
+    /// Claude/Codex, experimental Kimi/opencode/Grok at default pins, local
+    /// servers with a discoverable model). Never requires API keys.
+    #[arg(long, conflicts_with = "profile")]
+    pub auto: bool,
+
+    /// Path to a caucus config file (TOML)
+    #[arg(long)]
+    pub config: Option<PathBuf>,
 
     /// Verbose output (show model queries, strategy, agreement score on stderr)
     #[arg(short, long)]
@@ -24,16 +49,17 @@ pub struct AskArgs {
     #[arg(long)]
     pub system: Option<String>,
 
-    /// Consensus strategy to use
-    #[arg(short, long, default_value = "judge",
+    /// Consensus strategy to use (defaults to judge, or the profile's strategy)
+    #[arg(short, long,
         value_parser = ["majority-vote", "weighted-vote", "judge", "debate", "debate-then-vote"],
         long_help = "Consensus strategy to use:\n\
         \n  majority-vote     Count-based voting with fuzzy string matching (no LLM needed)\
         \n  weighted-vote     Candidates weighted by confidence/model reputation (no LLM needed)\
         \n  judge             A separate LLM evaluates all candidates and synthesizes the best response\
         \n  debate            Multi-round debate where candidates refine positions over rounds\
-        \n  debate-then-vote  Debate rounds followed by majority vote (hybrid)")]
-    pub strategy: String,
+        \n  debate-then-vote  Debate rounds followed by majority vote (hybrid)\
+        \n\nDefaults to judge, or the profile's strategy when --profile/--auto is used.")]
+    pub strategy: Option<String>,
 
     /// Output format
     #[arg(short, long, default_value = "plain",
@@ -52,7 +78,181 @@ pub struct AskArgs {
 
 pub async fn run(args: AskArgs) -> anyhow::Result<()> {
     let format: OutputFormat = args.format.parse()?;
-    let models = args.models.unwrap_or_else(default_models);
+    if args.profile.is_some() || args.auto || args.config.is_some() {
+        return run_council(args, format).await;
+    }
+    run_legacy(args, format).await
+}
+
+/// Profile/auto path: exact providers from member specs, bounded fan-out
+/// with deadlines and quorum, then the selected strategy via `resolve_multi`
+/// so debate refines each participant independently.
+async fn run_council(args: AskArgs, format: OutputFormat) -> anyhow::Result<()> {
+    let verbose = args.verbose;
+    let (_path, config) = council::load_config(args.config.as_deref())?;
+
+    let council = if args.auto {
+        let selection = council::auto_council(&config).await;
+        for exclusion in &selection.exclusions {
+            eprintln!("  {} {} excluded: {}", "·".dimmed(), exclusion.adapter, exclusion.reason);
+        }
+        selection.council
+    } else {
+        match config.resolve_profile(args.profile.as_deref()) {
+            Ok(council) => council,
+            Err(caucus_core::ConfigError::NoDefault) => config.resolve_profile(Some("deep"))?,
+            Err(error) => return Err(error.into()),
+        }
+    };
+
+    if council.members.is_empty() {
+        anyhow::bail!(
+            "auto council is empty — no ready local adapters found; run `caucus doctor` for details"
+        );
+    }
+
+    let strategy_name = args.strategy.clone().unwrap_or_else(|| council.strategy.clone());
+    // Reject a misspelled profile strategy before spending any provider
+    // requests. The validated strategy is constructed again after fan-out.
+    caucus_core::strategy_from_name(&strategy_name)?;
+    let deadline = RunDeadline::new(council.deadline_secs);
+
+    if verbose {
+        eprintln!(
+            "{} Council '{}' ({} member(s), quorum {}, strategy '{}')",
+            "▶".green(),
+            council.name.cyan(),
+            council.members.len(),
+            council.quorum,
+            strategy_name.cyan(),
+        );
+        for member in &council.members {
+            eprintln!("  {} {}", "·".dimmed(), member.to_string().yellow());
+        }
+    }
+
+    let multi = council::build_council_provider(&council, &config)?;
+    let requested_timeout = Duration::from_secs(
+        council
+            .request_timeout_secs
+            .or(council.deadline_secs)
+            .unwrap_or(caucus_core::DEFAULT_REQUEST_TIMEOUT.as_secs()),
+    );
+    let timeout = deadline.turn_timeout(requested_timeout)?;
+    let report = deadline
+        .wait(caucus_core::provider::fanout(
+            &multi,
+            &args.prompt,
+            args.system.as_deref(),
+            caucus_core::FanoutConfig { max_concurrency: 4, timeout, quorum: council.quorum },
+        ))
+        .await?;
+
+    for warning in report.warnings() {
+        eprintln!("  {} {}", "✗".red(), warning);
+    }
+    if !report.quorum_met() {
+        anyhow::bail!(
+            "quorum not met for council '{}': {}/{} required member(s) responded",
+            council.name,
+            report.successes.len(),
+            report.quorum,
+        );
+    }
+
+    let candidates: Vec<Candidate> = report
+        .successes
+        .iter()
+        .map(|s| {
+            Candidate::new(s.content.clone())
+                .with_model(s.model.clone())
+                .with_metadata("question", serde_json::json!(&args.prompt))
+                .with_metadata("latency_ms", serde_json::json!(s.latency_ms))
+                .with_metadata("transport", serde_json::json!(s.transport.to_string()))
+        })
+        .collect();
+
+    // Single member shortcut: skip consensus, just print the response.
+    if candidates.len() == 1 && strategy_name == "judge" {
+        if verbose {
+            eprintln!("{} Single member — returning response directly\n", "✓".green());
+        }
+        let result = ConsensusResult {
+            content: candidates[0].content.clone(),
+            strategy: "passthrough".into(),
+            agreement_score: 1.0,
+            candidates,
+            dissents: vec![],
+            reasoning: None,
+            metadata: Default::default(),
+        };
+        println!("{}", format.render(&result));
+        return Ok(());
+    }
+
+    // Judge/fallback LLM: the profile's designated judge when set, otherwise
+    // the first provider that actually returned a candidate. This prevents a
+    // tolerated fan-out failure from becoming a fatal judge call.
+    let judge = if strategy_needs_llm(&strategy_name) {
+        if council.judge.is_some() {
+            Some(council::select_judge(&council, &multi, &config)?)
+        } else {
+            let name =
+                candidates.first().and_then(|candidate| candidate.model.clone()).ok_or_else(
+                    || anyhow::anyhow!("no successful council member available as judge"),
+                )?;
+            let provider = multi.get(&name).ok_or_else(|| {
+                anyhow::anyhow!("successful council provider '{name}' disappeared")
+            })?;
+            Some((name, council::JudgeProvider::Borrowed(provider)))
+        }
+    } else {
+        None
+    };
+    if verbose && let Some((name, _)) = &judge {
+        eprintln!("  {} judge: {}", "·".dimmed(), name.yellow());
+    }
+    let judge_llm: Option<&dyn caucus_core::LlmProvider> =
+        judge.as_ref().map(|(_, provider)| provider.get());
+
+    if verbose {
+        eprintln!(
+            "{} Got {} candidate(s), running {}...",
+            "▶".green(),
+            candidates.len(),
+            strategy_name.cyan(),
+        );
+    }
+
+    // Always go through resolve_multi: the default impl falls back to
+    // resolve, while debate uses each member's own provider.
+    let result = if is_debate_strategy(&strategy_name) {
+        let strategy = MultiRoundDebate::with_config(DebateConfig {
+            max_rounds: args.rounds,
+            ..Default::default()
+        });
+        deadline.wait(strategy.resolve_multi(&candidates, judge_llm, Some(&multi))).await??
+    } else {
+        let strategy = caucus_core::strategy_from_name(&strategy_name)?;
+        deadline.wait(strategy.resolve_multi(&candidates, judge_llm, Some(&multi))).await??
+    };
+
+    if verbose {
+        eprintln!(
+            "{} Consensus reached (agreement: {:.0}%)\n",
+            "✓".green(),
+            result.agreement_score * 100.0,
+        );
+    }
+
+    println!("{}", format.render(&result));
+    Ok(())
+}
+
+/// Legacy path: API models keyed from environment variables.
+async fn run_legacy(args: AskArgs, format: OutputFormat) -> anyhow::Result<()> {
+    let strategy_name = args.strategy.clone().unwrap_or_else(|| "judge".to_string());
+    let models = args.models.clone().unwrap_or_else(default_models);
     let verbose = args.verbose;
 
     if verbose {
@@ -60,7 +260,7 @@ pub async fn run(args: AskArgs) -> anyhow::Result<()> {
             "{} Querying {} model(s) with strategy '{}'...",
             "▶".green(),
             models.len(),
-            args.strategy.cyan(),
+            strategy_name.cyan(),
         );
     }
 
@@ -107,7 +307,7 @@ pub async fn run(args: AskArgs) -> anyhow::Result<()> {
     }
 
     // Single model shortcut: skip consensus, just print the response directly
-    if candidates.len() == 1 && args.strategy == "judge" {
+    if candidates.len() == 1 && strategy_name == "judge" {
         if verbose {
             eprintln!("{} Single model — returning response directly\n", "✓".green(),);
         }
@@ -129,12 +329,12 @@ pub async fn run(args: AskArgs) -> anyhow::Result<()> {
             "{} Got {} candidate(s), running {}...",
             "▶".green(),
             candidates.len(),
-            args.strategy.cyan(),
+            strategy_name.cyan(),
         );
     }
 
     // Run consensus
-    let judge_llm: Option<Box<dyn caucus_core::LlmProvider>> = if strategy_needs_llm(&args.strategy)
+    let judge_llm: Option<Box<dyn caucus_core::LlmProvider>> = if strategy_needs_llm(&strategy_name)
     {
         // Use the first model as the judge
         let judge_model = models.first().expect("no models configured");
@@ -142,15 +342,22 @@ pub async fn run(args: AskArgs) -> anyhow::Result<()> {
     } else {
         None
     };
+    let participant_provider = if is_debate_strategy(&strategy_name) {
+        Some(super::build_provider(&models)?)
+    } else {
+        None
+    };
 
-    let result = if is_debate_strategy(&args.strategy) {
+    let result = if is_debate_strategy(&strategy_name) {
         let strategy = MultiRoundDebate::with_config(DebateConfig {
             max_rounds: args.rounds,
             ..Default::default()
         });
-        strategy.resolve(&candidates, judge_llm.as_deref()).await?
+        strategy
+            .resolve_multi(&candidates, judge_llm.as_deref(), participant_provider.as_ref())
+            .await?
     } else {
-        consensus(&candidates, &args.strategy, judge_llm.as_deref()).await?
+        consensus(&candidates, &strategy_name, judge_llm.as_deref()).await?
     };
 
     if verbose {
@@ -183,4 +390,59 @@ fn strategy_needs_llm(name: &str) -> bool {
             | "debate_then_vote"
             | "debate-then-vote"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: AskArgs,
+    }
+
+    fn parse(argv: &[&str]) -> Result<AskArgs, clap::Error> {
+        TestCli::try_parse_from(argv).map(|cli| cli.args)
+    }
+
+    #[test]
+    fn legacy_models_still_parse() {
+        let args = parse(&["caucus", "what is 2+2", "-m", "gpt-5.2,claude-opus-4-6"]).unwrap();
+        assert_eq!(args.prompt, "what is 2+2");
+        assert_eq!(
+            args.models.unwrap(),
+            vec!["gpt-5.2".to_string(), "claude-opus-4-6".to_string()]
+        );
+        assert!(args.profile.is_none());
+        assert!(!args.auto);
+        assert!(args.strategy.is_none()); // legacy default applied at run time
+    }
+
+    #[test]
+    fn profile_and_auto_parse() {
+        let args = parse(&["caucus", "q", "--profile", "deep", "--config", "caucus.toml"]).unwrap();
+        assert_eq!(args.profile.as_deref(), Some("deep"));
+        assert_eq!(args.config, Some(PathBuf::from("caucus.toml")));
+
+        let args = parse(&["caucus", "q", "--auto"]).unwrap();
+        assert!(args.auto);
+        assert!(args.profile.is_none());
+    }
+
+    #[test]
+    fn profile_and_auto_conflict_with_models() {
+        assert!(parse(&["caucus", "q", "-m", "gpt-5.2", "--profile", "deep"]).is_err());
+        assert!(parse(&["caucus", "q", "-m", "gpt-5.2", "--auto"]).is_err());
+        assert!(parse(&["caucus", "q", "-m", "gpt-5.2", "--config", "caucus.toml"]).is_err());
+    }
+
+    #[test]
+    fn strategy_override_is_optional_and_validated() {
+        let args = parse(&["caucus", "q", "--profile", "deep", "-s", "debate"]).unwrap();
+        assert_eq!(args.strategy.as_deref(), Some("debate"));
+        assert!(parse(&["caucus", "q", "-s", "bogus"]).is_err());
+    }
 }

--- a/crates/caucus-cli/src/commands/council.rs
+++ b/crates/caucus-cli/src/commands/council.rs
@@ -1,0 +1,697 @@
+//! Shared council helpers: config loading, typed adapter overrides,
+//! `MultiProvider` construction from exact member specs, and the zero-key
+//! auto council.
+//!
+//! The auto council is built only from adapters that are reachable without
+//! any API keys: ready CLI adapters (Claude, Codex, and the experimental
+//! Kimi/opencode/Grok adapters) at documented default pins, and local servers (Ollama,
+//! LM Studio) only when a model is configured or safely discoverable. Remote
+//! API adapters are always excluded — auto never requires API keys — and
+//! every exclusion is reported with its reason.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use caucus_core::adapters::{self, Discovered, MemberSpec, Utility};
+use caucus_core::provider::MultiProvider;
+use caucus_core::{AdapterOverrides, Config, Council, ProcessLimits, Transport, provider_for_with};
+use serde::Deserialize;
+
+/// Default model pin for Claude in the auto council (matches the built-in
+/// `deep` profile's pin).
+pub const AUTO_CLAUDE_MODEL: &str = "opus";
+/// Default model pin for Codex in the auto council (`default` omits `-m`).
+pub const AUTO_CODEX_MODEL: &str = "default";
+/// Default model pin for the experimental Kimi adapter.
+pub const AUTO_KIMI_MODEL: &str = "kimi-code/k3";
+/// Default model pin for the experimental opencode adapter.
+pub const AUTO_OPENCODE_MODEL: &str = "zai-coding-plan/glm-5.2";
+/// Default model pin for the experimental Grok Build adapter.
+pub const AUTO_GROK_MODEL: &str = "grok-4.5";
+/// Default effort for auto-council CLI members (supported by all five).
+pub const AUTO_EFFORT: &str = "high";
+
+/// Load configuration: explicit `--config` path, then the standard discovery
+/// order. Returns `(None, Config::default())` when no file exists. Legacy
+/// schema migration warnings are surfaced on stderr.
+pub fn load_config(explicit: Option<&Path>) -> anyhow::Result<(Option<PathBuf>, Config)> {
+    match Config::discover(explicit)? {
+        Some((path, config)) => {
+            validate_adapter_configs(&config)?;
+            for warning in &config.warnings {
+                eprintln!("config warning: {warning}");
+            }
+            Ok((Some(path), config))
+        }
+        None => Ok((None, Config::default())),
+    }
+}
+
+/// Validate every adapter section up front, including adapters that are not
+/// members of the selected profile. This keeps `doctor` honest and prevents
+/// misspelled execution settings from remaining dormant until a later
+/// profile happens to use that adapter.
+fn validate_adapter_configs(config: &Config) -> anyhow::Result<()> {
+    for name in config.adapters.keys() {
+        let utility: Utility = name.parse().map_err(|error| {
+            anyhow::anyhow!("invalid adapter section `[adapters.{name}]`: {error}")
+        })?;
+        if utility.as_str() != name {
+            anyhow::bail!(
+                "invalid adapter section `[adapters.{name}]`: use the canonical adapter id `[adapters.{}]`",
+                utility.as_str()
+            );
+        }
+        adapter_config(config, utility)
+            .map_err(|error| anyhow::anyhow!("invalid `[adapters.{name}]` config: {error}"))?;
+    }
+    Ok(())
+}
+
+/// Typed `[adapters.<id>]` overrides. Unknown keys are rejected so a typo
+/// cannot silently disable a safety or execution setting.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdapterConfig {
+    /// Explicit path to the adapter binary (skips PATH lookup).
+    pub binary_path: Option<PathBuf>,
+    /// Wall-clock limit per run; the child is killed on expiry.
+    pub timeout_secs: Option<u64>,
+    /// Stdout cap; excess is truncated.
+    pub max_stdout_bytes: Option<usize>,
+    /// Stderr cap; excess is truncated.
+    pub max_stderr_bytes: Option<usize>,
+    /// Exact model pin used by the auto council for local-server adapters
+    /// (ollama, lmstudio) when live discovery finds nothing.
+    pub model: Option<String>,
+    /// Explicit environment passed only to this adapter's child process.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+}
+
+/// Parse the typed overrides for one adapter from the loaded config.
+pub fn adapter_config(config: &Config, utility: Utility) -> anyhow::Result<AdapterConfig> {
+    match config.adapter_config(utility.as_str()) {
+        None => Ok(AdapterConfig::default()),
+        Some(value) => Ok(AdapterConfig::deserialize(value.clone())?),
+    }
+}
+
+/// Map typed config overrides into core [`AdapterOverrides`].
+#[cfg(test)]
+pub fn adapter_overrides(config: &Config, utility: Utility) -> anyhow::Result<AdapterOverrides> {
+    adapter_overrides_with_timeout(config, utility, None)
+}
+
+fn adapter_overrides_with_timeout(
+    config: &Config,
+    utility: Utility,
+    request_timeout: Option<Duration>,
+) -> anyhow::Result<AdapterOverrides> {
+    let typed = adapter_config(config, utility)?;
+    let mut limits = ProcessLimits::default();
+    let mut touched = false;
+    if typed.timeout_secs == Some(0) {
+        anyhow::bail!("[adapters.{}].timeout_secs must be at least 1", utility.as_str());
+    }
+    let configured_timeout = typed.timeout_secs.map(Duration::from_secs);
+    if let Some(timeout) = match (configured_timeout, request_timeout) {
+        (Some(configured), Some(request)) => Some(configured.min(request)),
+        (Some(configured), None) => Some(configured),
+        (None, Some(request)) => Some(request),
+        (None, None) => None,
+    } {
+        limits.timeout = timeout;
+        touched = true;
+    }
+    if let Some(max) = typed.max_stdout_bytes {
+        limits.max_stdout_bytes = max;
+        touched = true;
+    }
+    if let Some(max) = typed.max_stderr_bytes {
+        limits.max_stderr_bytes = max;
+        touched = true;
+    }
+    Ok(AdapterOverrides {
+        binary_path: typed.binary_path,
+        limits: touched.then_some(limits),
+        env: typed.env.into_iter().collect(),
+    })
+}
+
+/// Build a [`MultiProvider`] from a council's exact member specs. Each
+/// provider is registered under the member's exact `utility:model@effort`
+/// string, so candidates and per-participant debate lookup line up exactly.
+pub fn build_council_provider(council: &Council, config: &Config) -> anyhow::Result<MultiProvider> {
+    let mut multi = MultiProvider::new();
+    let request_timeout =
+        council.request_timeout_secs.or(council.deadline_secs).map(Duration::from_secs);
+    for member in &council.members {
+        let overrides = adapter_overrides_with_timeout(config, member.utility, request_timeout)?;
+        let provider = provider_for_with(member, &overrides)?;
+        multi = multi.add_shared(member.to_string(), std::sync::Arc::from(provider));
+    }
+    Ok(multi)
+}
+
+/// The judge for strategies that need one, either borrowed from the council
+/// provider set or built dedicated when the designated judge is not a member.
+pub enum JudgeProvider<'a> {
+    Borrowed(&'a dyn caucus_core::LlmProvider),
+    Owned(Box<dyn caucus_core::LlmProvider>),
+}
+
+impl JudgeProvider<'_> {
+    pub fn get(&self) -> &dyn caucus_core::LlmProvider {
+        match self {
+            Self::Borrowed(p) => *p,
+            Self::Owned(p) => p.as_ref(),
+        }
+    }
+}
+
+/// Pick the judge for a council run: the profile's designated `judge` member
+/// when set — reusing the council provider when the judge is also a member,
+/// building a dedicated one when it is not — and otherwise the first council
+/// member's provider. Returns the exact judge member string and its provider.
+pub fn select_judge<'a>(
+    council: &Council,
+    multi: &'a MultiProvider,
+    config: &Config,
+) -> anyhow::Result<(String, JudgeProvider<'a>)> {
+    if let Some(judge) = &council.judge {
+        let name = judge.to_string();
+        if let Some(provider) = multi.get(&name) {
+            return Ok((name, JudgeProvider::Borrowed(provider)));
+        }
+        let request_timeout =
+            council.request_timeout_secs.or(council.deadline_secs).map(Duration::from_secs);
+        let overrides = adapter_overrides_with_timeout(config, judge.utility, request_timeout)?;
+        return Ok((name, JudgeProvider::Owned(provider_for_with(judge, &overrides)?)));
+    }
+    let first = multi.models().into_iter().next().expect("council is non-empty");
+    Ok((first.to_string(), JudgeProvider::Borrowed(multi.get(first).expect("registered above"))))
+}
+
+/// An adapter left out of the auto council, with the honest reason why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutoExclusion {
+    pub adapter: String,
+    pub reason: String,
+}
+
+/// The auto council plus the adapters that were excluded from it.
+#[derive(Debug, Clone)]
+pub struct AutoSelection {
+    pub council: Council,
+    pub exclusions: Vec<AutoExclusion>,
+}
+
+/// Build the zero-key auto council from live discovery. Probes PATH and
+/// local-server ports (and, for up local servers, their model lists); never
+/// reads credentials.
+pub async fn auto_council(config: &Config) -> AutoSelection {
+    let discovered = adapters::discover().await;
+    let mut configured_models = BTreeMap::new();
+    let mut probed_models = BTreeMap::new();
+    for d in &discovered {
+        let id = d.descriptor.id;
+        if let Ok(utility) = id.parse::<Utility>()
+            && let Ok(typed) = adapter_config(config, utility)
+            && let Some(model) = typed.model
+        {
+            configured_models.insert(id.to_string(), model);
+        }
+        if d.descriptor.transport == Transport::LocalServer
+            && d.readiness.is_ready()
+            && let Some(model) = probe_first_local_model(d.descriptor.base_url.unwrap_or("")).await
+        {
+            probed_models.insert(id.to_string(), model);
+        }
+    }
+    let (members, exclusions) = select_auto(&discovered, &configured_models, &probed_models);
+    let quorum = members.len().clamp(1, 3);
+    let council = Council {
+        name: "auto".to_string(),
+        description: Some(
+            "Zero-key council from locally discovered adapters (no API keys required)".to_string(),
+        ),
+        members,
+        judge: None,
+        strategy: "judge".to_string(),
+        quorum,
+        deadline_secs: Some(600),
+        request_timeout_secs: None,
+        budget_usd: None,
+    };
+    AutoSelection { council, exclusions }
+}
+
+/// Pure selection step for the auto council, split out for testing. Uses
+/// documented default pins for CLI adapters; local servers need a configured
+/// or probed model; API adapters and ACP are always excluded.
+pub fn select_auto(
+    discovered: &[Discovered],
+    configured_models: &BTreeMap<String, String>,
+    probed_models: &BTreeMap<String, String>,
+) -> (Vec<MemberSpec>, Vec<AutoExclusion>) {
+    let mut members = Vec::new();
+    let mut exclusions = Vec::new();
+    for d in discovered {
+        let id = d.descriptor.id;
+        let default_pin = match id {
+            "claude" => Some(AUTO_CLAUDE_MODEL),
+            "codex" => Some(AUTO_CODEX_MODEL),
+            "kimi" => Some(AUTO_KIMI_MODEL),
+            "opencode" => Some(AUTO_OPENCODE_MODEL),
+            "grok" => Some(AUTO_GROK_MODEL),
+            _ => None,
+        };
+        match d.descriptor.transport {
+            Transport::Command => {
+                if !d.readiness.is_ready() {
+                    exclusions.push(AutoExclusion {
+                        adapter: id.to_string(),
+                        reason: d.readiness.to_string(),
+                    });
+                    continue;
+                }
+                let pin = default_pin.expect("command adapters have a default pin");
+                let spec = format!("{id}:{pin}@{AUTO_EFFORT}");
+                match spec.parse::<MemberSpec>() {
+                    Ok(member) => members.push(member),
+                    Err(e) => exclusions.push(AutoExclusion {
+                        adapter: id.to_string(),
+                        reason: format!("default pin `{spec}` is invalid: {e}"),
+                    }),
+                }
+            }
+            Transport::LocalServer => {
+                if !d.readiness.is_ready() {
+                    exclusions.push(AutoExclusion {
+                        adapter: id.to_string(),
+                        reason: d.readiness.to_string(),
+                    });
+                    continue;
+                }
+                let model = configured_models.get(id).or_else(|| probed_models.get(id));
+                match model {
+                    Some(model) => match format!("{id}:{model}").parse::<MemberSpec>() {
+                        Ok(member) => members.push(member),
+                        Err(e) => exclusions.push(AutoExclusion {
+                            adapter: id.to_string(),
+                            reason: format!("model pin `{model}` is invalid: {e}"),
+                        }),
+                    },
+                    None => exclusions.push(AutoExclusion {
+                        adapter: id.to_string(),
+                        reason: format!(
+                            "server is up but no model could be discovered; pin one with \
+                             `[adapters.{id}] model = \"...\"`"
+                        ),
+                    }),
+                }
+            }
+            Transport::Api => exclusions.push(AutoExclusion {
+                adapter: id.to_string(),
+                reason: "auto never requires API keys; add it to a profile to use it".to_string(),
+            }),
+            Transport::Acp => exclusions
+                .push(AutoExclusion { adapter: id.to_string(), reason: d.readiness.to_string() }),
+        }
+    }
+    (members, exclusions)
+}
+
+/// Best-effort model discovery for a local OpenAI-compatible server, with a
+/// short timeout. Ollama: `GET /api/tags` → `models[].name`; LM Studio:
+/// `GET /v1/models` → `data[].id`. Returns `None` on any failure — a failed
+/// probe simply means the adapter is excluded from auto.
+async fn probe_first_local_model(base_url: &str) -> Option<String> {
+    let (url, list_path) = local_model_probe(base_url);
+    let body = tokio::time::timeout(Duration::from_millis(800), http_get(&url)).await.ok()??;
+    let json: serde_json::Value = serde_json::from_str(&body).ok()?;
+    let entries = json.get(list_path)?.as_array()?;
+    for entry in entries {
+        let name = entry.get("name").or_else(|| entry.get("id")).and_then(|v| v.as_str());
+        if let Some(name) = name
+            && !name.trim().is_empty()
+            && !name.chars().any(char::is_whitespace)
+        {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+fn local_model_probe(base_url: &str) -> (String, &'static str) {
+    let (url, list_path) = if base_url.contains(":11434") {
+        // Ollama's `/api/tags` lives at the server root, not under `/v1`.
+        let root = base_url.trim_end_matches('/').trim_end_matches("/v1");
+        (format!("{root}/api/tags"), "models")
+    } else {
+        // LM Studio exposes the OpenAI-compatible list at `/v1/models`.
+        (format!("{}/models", base_url.trim_end_matches('/')), "data")
+    };
+    (url, list_path)
+}
+
+/// Minimal HTTP/1.1 GET over a raw TCP stream (no TLS, local servers only).
+/// Never a shell; only the well-known local probe URLs above reach this.
+async fn http_get(url: &str) -> Option<String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let rest = url.split("://").nth(1)?;
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, "/"),
+    };
+    let mut stream = tokio::net::TcpStream::connect(authority).await.ok()?;
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: {authority}\r\nAccept: application/json\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).await.ok()?;
+    let mut buf = Vec::with_capacity(64 * 1024);
+    stream.take(1024 * 1024).read_to_end(&mut buf).await.ok()?;
+    let text = String::from_utf8_lossy(&buf);
+    let (_, body) = text.split_once("\r\n\r\n")?;
+    // Tolerate chunked framing by slicing out the JSON document.
+    let start = body.find('{')?;
+    let end = body.rfind('}')?;
+    (start <= end).then(|| body[start..=end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use caucus_core::adapters::{Readiness, descriptor, descriptors};
+
+    use super::*;
+
+    fn discovered_with(ready_ids: &[&str]) -> Vec<Discovered> {
+        descriptors()
+            .iter()
+            .map(|d| {
+                let readiness = match d.transport {
+                    Transport::Command => {
+                        if ready_ids.contains(&d.id) {
+                            Readiness::Ready
+                        } else {
+                            Readiness::MissingBinary(d.binary.unwrap())
+                        }
+                    }
+                    Transport::LocalServer => {
+                        if ready_ids.contains(&d.id) {
+                            Readiness::Ready
+                        } else {
+                            Readiness::ServerDown(d.base_url.unwrap())
+                        }
+                    }
+                    Transport::Api => Readiness::Ready,
+                    Transport::Acp => Readiness::Unsupported("not implemented".to_string()),
+                };
+                Discovered { descriptor: d, readiness }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn adapter_overrides_map_typed_fields() {
+        let config = Config::from_toml_str(
+            r#"
+[adapters.claude]
+binary_path = "/usr/local/bin/claude"
+timeout_secs = 900
+max_stdout_bytes = 2097152
+max_stderr_bytes = 4096
+"#,
+        )
+        .unwrap();
+        let overrides = adapter_overrides(&config, Utility::Claude).unwrap();
+        assert_eq!(overrides.binary_path, Some(PathBuf::from("/usr/local/bin/claude")));
+        let limits = overrides.limits.expect("limits set");
+        assert_eq!(limits.timeout, Duration::from_secs(900));
+        assert_eq!(limits.max_stdout_bytes, 2097152);
+        assert_eq!(limits.max_stderr_bytes, 4096);
+    }
+
+    #[test]
+    fn adapter_overrides_default_when_unset_or_partial() {
+        let config = Config::from_toml_str(
+            r#"
+[adapters.kimi]
+timeout_secs = 300
+env = { NO_COLOR = "1" }
+"#,
+        )
+        .unwrap();
+        let kimi = adapter_overrides(&config, Utility::Kimi).unwrap();
+        assert_eq!(kimi.binary_path, None);
+        assert_eq!(kimi.limits.unwrap().timeout, Duration::from_secs(300));
+        assert_eq!(kimi.env, vec![("NO_COLOR".to_string(), "1".to_string())]);
+        let codex = adapter_overrides(&config, Utility::Codex).unwrap();
+        assert!(codex.binary_path.is_none());
+        assert!(codex.limits.is_none());
+    }
+
+    #[test]
+    fn all_adapter_sections_are_validated_even_when_unused() {
+        let typo = Config::from_toml_str(
+            r#"
+[adapters.kimi]
+cli_path = "/usr/local/bin/kimi"
+"#,
+        )
+        .unwrap();
+        let error = validate_adapter_configs(&typo).unwrap_err().to_string();
+        assert!(error.contains("unknown field `cli_path`"), "got: {error}");
+
+        let unknown = Config::from_toml_str(
+            r#"
+[adapters.future]
+timeout_secs = 30
+"#,
+        )
+        .unwrap();
+        let error = validate_adapter_configs(&unknown).unwrap_err().to_string();
+        assert!(error.contains("[adapters.future]"), "got: {error}");
+    }
+
+    #[test]
+    fn profile_request_timeout_reaches_process_limits_and_respects_stricter_adapter_cap() {
+        let config = Config::from_toml_str(
+            r#"
+[adapters.claude]
+timeout_secs = 90
+"#,
+        )
+        .unwrap();
+        let strict = adapter_overrides_with_timeout(
+            &config,
+            Utility::Claude,
+            Some(Duration::from_secs(240)),
+        )
+        .unwrap();
+        assert_eq!(strict.limits.unwrap().timeout, Duration::from_secs(90));
+
+        let inherited = adapter_overrides_with_timeout(
+            &Config::default(),
+            Utility::Claude,
+            Some(Duration::from_secs(240)),
+        )
+        .unwrap();
+        assert_eq!(inherited.limits.unwrap().timeout, Duration::from_secs(240));
+    }
+
+    #[test]
+    fn adapter_zero_timeout_is_rejected() {
+        let config = Config::from_toml_str(
+            r#"
+[adapters.claude]
+timeout_secs = 0
+"#,
+        )
+        .unwrap();
+        let error = adapter_overrides(&config, Utility::Claude).unwrap_err().to_string();
+        assert!(error.contains("must be at least 1"), "got: {error}");
+    }
+
+    #[test]
+    fn auto_includes_ready_clis_at_documented_pins() {
+        let discovered = discovered_with(&["claude", "codex", "kimi", "opencode", "grok"]);
+        let (members, exclusions) = select_auto(&discovered, &BTreeMap::new(), &BTreeMap::new());
+        let rendered: Vec<String> = members.iter().map(|m| m.to_string()).collect();
+        assert_eq!(
+            rendered,
+            vec![
+                "claude:opus@high",
+                "codex:default@high",
+                "kimi:kimi-code/k3@high",
+                "opencode:zai-coding-plan/glm-5.2@high",
+                "grok:grok-4.5@high",
+            ]
+        );
+        // Everything else is excluded with a reason — nothing silently dropped.
+        let excluded: Vec<&str> = exclusions.iter().map(|e| e.adapter.as_str()).collect();
+        assert_eq!(excluded, vec!["ollama", "lmstudio", "gemini", "acp"]);
+        assert!(exclusions.iter().all(|e| !e.reason.is_empty()));
+    }
+
+    #[test]
+    fn auto_excludes_missing_binaries_honestly() {
+        let discovered = discovered_with(&["codex"]);
+        let (members, exclusions) = select_auto(&discovered, &BTreeMap::new(), &BTreeMap::new());
+        assert_eq!(members.len(), 1);
+        let claude = exclusions.iter().find(|e| e.adapter == "claude").unwrap();
+        assert!(claude.reason.contains("missing binary"));
+    }
+
+    #[test]
+    fn auto_local_servers_need_a_model() {
+        // Server up, nothing configured or probed → excluded with guidance.
+        let discovered = discovered_with(&["ollama"]);
+        let (members, exclusions) = select_auto(&discovered, &BTreeMap::new(), &BTreeMap::new());
+        assert!(members.is_empty());
+        let ollama = exclusions.iter().find(|e| e.adapter == "ollama").unwrap();
+        assert!(ollama.reason.contains("[adapters.ollama]"));
+
+        // Configured model wins; probed model is the fallback.
+        let configured = BTreeMap::from([("ollama".to_string(), "llama3.2:latest".to_string())]);
+        let (members, _) = select_auto(&discovered, &configured, &BTreeMap::new());
+        assert_eq!(members[0].to_string(), "ollama:llama3.2:latest");
+
+        let probed = BTreeMap::from([("ollama".to_string(), "qwen3:8b".to_string())]);
+        let (members, _) = select_auto(&discovered, &BTreeMap::new(), &probed);
+        assert_eq!(members[0].to_string(), "ollama:qwen3:8b");
+    }
+
+    #[test]
+    fn local_model_probe_uses_each_servers_actual_listing_endpoint() {
+        assert_eq!(
+            local_model_probe("http://localhost:11434/v1"),
+            ("http://localhost:11434/api/tags".to_string(), "models")
+        );
+        assert_eq!(
+            local_model_probe("http://localhost:1234/v1"),
+            ("http://localhost:1234/v1/models".to_string(), "data")
+        );
+    }
+
+    #[tokio::test]
+    async fn local_model_probe_reads_a_real_async_http_response() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let count = stream.read(&mut request).await.unwrap();
+            assert!(String::from_utf8_lossy(&request[..count]).starts_with("GET /v1/models "));
+            let body = r#"{"data":[{"id":"qwen-test"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let model = probe_first_local_model(&format!("http://{address}/v1")).await;
+        assert_eq!(model.as_deref(), Some("qwen-test"));
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn auto_never_includes_api_adapters() {
+        let discovered = discovered_with(&[]);
+        let (members, exclusions) = select_auto(&discovered, &BTreeMap::new(), &BTreeMap::new());
+        assert!(members.iter().all(|m| m.utility.descriptor().transport != Transport::Api));
+        let gemini = exclusions.iter().find(|e| e.adapter == "gemini").unwrap();
+        assert!(gemini.reason.contains("API keys"), "gemini: {}", gemini.reason);
+    }
+
+    #[test]
+    fn council_provider_uses_exact_member_strings() {
+        let council = Council {
+            name: "t".to_string(),
+            description: None,
+            members: vec!["ollama:llama3.2:latest".parse().unwrap()],
+            judge: None,
+            strategy: "judge".to_string(),
+            quorum: 1,
+            deadline_secs: None,
+            request_timeout_secs: None,
+            budget_usd: None,
+        };
+        let multi = build_council_provider(&council, &Config::default()).unwrap();
+        assert_eq!(multi.models(), vec!["ollama:llama3.2:latest"]);
+        assert!(multi.get("ollama:llama3.2:latest").is_some());
+    }
+
+    #[test]
+    fn council_provider_requires_keys_for_api_members() {
+        // Avoid mutating the process environment while parallel tests may be
+        // reading it. A configured developer key makes this branch inapplicable.
+        if std::env::var_os("GEMINI_API_KEY").is_some() {
+            return;
+        }
+        let council = Council {
+            name: "t".to_string(),
+            description: None,
+            members: vec!["gemini:gemini-3.1-pro-preview".parse().unwrap()],
+            judge: None,
+            strategy: "judge".to_string(),
+            quorum: 1,
+            deadline_secs: None,
+            request_timeout_secs: None,
+            budget_usd: None,
+        };
+        let result = build_council_provider(&council, &Config::default());
+        let err = match result {
+            Ok(_) => panic!("api member without a key must fail"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("GEMINI_API_KEY"));
+    }
+
+    #[test]
+    fn select_judge_prefers_designated_judge() {
+        let member = |s: &str| s.parse().unwrap();
+        let council = Council {
+            name: "t".to_string(),
+            description: None,
+            members: vec![member("ollama:llama3.2:latest"), member("ollama:qwen3:8b")],
+            judge: Some(member("ollama:qwen3:8b")),
+            strategy: "judge".to_string(),
+            quorum: 1,
+            deadline_secs: None,
+            request_timeout_secs: None,
+            budget_usd: None,
+        };
+        let multi = build_council_provider(&council, &Config::default()).unwrap();
+
+        // Designated judge that is also a member reuses the council provider.
+        let (name, judge) = select_judge(&council, &multi, &Config::default()).unwrap();
+        assert_eq!(name, "ollama:qwen3:8b");
+        assert!(matches!(judge, JudgeProvider::Borrowed(_)));
+        assert_eq!(judge.get().transport(), Transport::LocalServer);
+
+        // No designated judge falls back to the first member.
+        let council = Council { judge: None, ..council };
+        let (name, _) = select_judge(&council, &multi, &Config::default()).unwrap();
+        assert_eq!(name, "ollama:llama3.2:latest");
+
+        // A designated judge outside the member list gets a dedicated provider.
+        let council = Council { judge: Some(member("ollama:phi4")), ..council };
+        let (name, judge) = select_judge(&council, &multi, &Config::default()).unwrap();
+        assert_eq!(name, "ollama:phi4");
+        assert!(matches!(judge, JudgeProvider::Owned(_)));
+    }
+
+    #[test]
+    fn descriptor_lookup_for_every_utility() {
+        for id in caucus_core::utility_ids() {
+            assert!(descriptor(id).unwrap().id == id);
+        }
+    }
+}

--- a/crates/caucus-cli/src/commands/debate.rs
+++ b/crates/caucus-cli/src/commands/debate.rs
@@ -1,9 +1,9 @@
 use caucus_core::strategy::debate::DebateConfig;
-use caucus_core::{Candidate, ConsensusStrategy, MultiRoundDebate, OutputFormat};
+use caucus_core::{Candidate, ConsensusStrategy, FanoutConfig, MultiRoundDebate, OutputFormat};
 use clap::Args;
 use colored::Colorize;
 
-use super::{build_provider, build_single_provider, default_models};
+use super::{build_provider, default_models};
 
 #[derive(Args)]
 pub struct DebateArgs {
@@ -35,36 +35,55 @@ pub async fn run(args: DebateArgs) -> anyhow::Result<()> {
         models.len(),
     );
 
-    // Generate initial positions
+    // Generate initial positions concurrently. A single unavailable member is
+    // a recorded warning rather than aborting an otherwise viable debate.
     let provider = build_provider(&models)?;
-    let mut candidates = Vec::new();
-
-    for model in &models {
-        let llm =
-            provider.get(model).ok_or_else(|| anyhow::anyhow!("No provider for model: {model}"))?;
-
-        eprintln!("  {} Getting initial position from {}...", "·".dimmed(), model.yellow());
-        let response = llm.complete(&args.prompt, None).await?;
-        eprintln!("  {} {} responded ({} chars)", "✓".green(), model, response.len(),);
-        candidates.push(
-            Candidate::new(response)
-                .with_model(model.clone())
-                .with_metadata("question", serde_json::json!(&args.prompt)),
-        );
+    let report = caucus_core::provider::fanout(
+        &provider,
+        &args.prompt,
+        None,
+        FanoutConfig { quorum: 1, ..Default::default() },
+    )
+    .await;
+    for warning in report.warnings() {
+        eprintln!("  {} {}", "✗".red(), warning);
     }
+    if !report.quorum_met() {
+        anyhow::bail!("no debate participant returned an initial position");
+    }
+    let candidates: Vec<Candidate> = report
+        .successes
+        .iter()
+        .map(|success| {
+            eprintln!(
+                "  {} {} responded ({} chars)",
+                "✓".green(),
+                success.model,
+                success.content.len(),
+            );
+            Candidate::new(success.content.clone())
+                .with_model(success.model.clone())
+                .with_metadata("question", serde_json::json!(&args.prompt))
+        })
+        .collect();
 
     eprintln!();
 
     // Run debate
-    let judge_model = models.first().expect("no models configured");
-    let judge_llm = build_single_provider(judge_model)?;
+    let judge_model = candidates
+        .first()
+        .and_then(|candidate| candidate.model.as_deref())
+        .ok_or_else(|| anyhow::anyhow!("no successful participant available as judge"))?;
+    let judge_llm = provider
+        .get(judge_model)
+        .ok_or_else(|| anyhow::anyhow!("successful debate provider '{judge_model}' disappeared"))?;
 
     let strategy = MultiRoundDebate::with_config(DebateConfig {
         max_rounds: args.rounds,
         ..Default::default()
     });
 
-    let result = strategy.resolve(&candidates, Some(judge_llm.as_ref())).await?;
+    let result = strategy.resolve_multi(&candidates, Some(judge_llm), Some(&provider)).await?;
 
     eprintln!(
         "\n{} Debate concluded (agreement: {:.0}%)\n",

--- a/crates/caucus-cli/src/commands/doctor.rs
+++ b/crates/caucus-cli/src/commands/doctor.rs
@@ -1,0 +1,285 @@
+//! `caucus doctor`: report adapter readiness, config validity, and profile
+//! health. Probes the local machine only — never reads credentials.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use caucus_core::adapters::{self, AdapterDescriptor, Readiness};
+use caucus_core::{Config, Transport, builtin_profiles};
+use clap::Args;
+use colored::Colorize;
+
+use super::council;
+
+#[derive(Args)]
+pub struct DoctorArgs {
+    /// Emit the full report as JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Path to a caucus config file (TOML)
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+}
+
+/// One adapter's health row.
+#[derive(Debug, Clone, serde::Serialize)]
+struct AdapterRow {
+    id: String,
+    transport: String,
+    stability: String,
+    ready: bool,
+    readiness: String,
+    efforts: Vec<String>,
+    notes: String,
+}
+
+/// One profile's health row.
+#[derive(Debug, Clone, serde::Serialize)]
+struct ProfileRow {
+    name: String,
+    builtin: bool,
+    strategy: String,
+    quorum: usize,
+    members: usize,
+    ready_members: usize,
+    /// Enough ready members to satisfy quorum right now.
+    usable: bool,
+}
+
+/// Readiness for one descriptor, honoring a `binary_path` override from the
+/// loaded config (discovery itself only probes PATH).
+fn readiness_for(
+    d: &AdapterDescriptor,
+    discovered: &Readiness,
+    config: Option<&Config>,
+) -> (bool, String) {
+    if d.transport == Transport::Command
+        && let Some(config) = config
+        && let Ok(utility) = d.id.parse()
+        && let Ok(typed) = council::adapter_config(config, utility)
+        && let Some(path) = typed.binary_path
+    {
+        return if path.is_file() {
+            (true, format!("ready (binary override {})", path.display()))
+        } else {
+            (false, format!("binary override {} does not exist", path.display()))
+        };
+    }
+    (discovered.is_ready(), discovered.to_string())
+}
+
+/// Per-profile readiness against the set of ready adapter ids. Pure so it is
+/// unit-testable without probing the machine.
+fn profile_rows(config: &Config, ready: &BTreeMap<String, bool>) -> Vec<ProfileRow> {
+    config
+        .list_profiles()
+        .into_iter()
+        .filter_map(|(name, _profile)| {
+            let council = config.resolve_profile(Some(&name)).ok()?;
+            let ready_members = council
+                .members
+                .iter()
+                .filter(|m| ready.get(m.utility.as_str()).copied().unwrap_or(false))
+                .count();
+            Some(ProfileRow {
+                builtin: builtin_profiles().contains_key(&name)
+                    && !config.profiles.contains_key(&name),
+                strategy: council.strategy,
+                quorum: council.quorum,
+                members: council.members.len(),
+                ready_members,
+                usable: ready_members >= council.quorum,
+                name,
+            })
+        })
+        .collect()
+}
+
+/// Build the full machine-readable report.
+async fn report(config_path: Option<PathBuf>, config: &Config) -> serde_json::Value {
+    let discovered = adapters::discover().await;
+    let mut ready: BTreeMap<String, bool> = BTreeMap::new();
+    let rows: Vec<AdapterRow> = discovered
+        .iter()
+        .map(|d| {
+            let (is_ready, label) = readiness_for(d.descriptor, &d.readiness, Some(config));
+            ready.insert(d.descriptor.id.to_string(), is_ready);
+            AdapterRow {
+                id: d.descriptor.id.to_string(),
+                transport: d.descriptor.transport.to_string(),
+                stability: d.descriptor.stability.to_string(),
+                ready: is_ready,
+                readiness: label,
+                efforts: d.descriptor.efforts.iter().map(|e| e.as_str().to_string()).collect(),
+                notes: d.descriptor.notes.to_string(),
+            }
+        })
+        .collect();
+
+    let profiles = profile_rows(config, &ready);
+    let usable_profiles = profiles.iter().filter(|p| p.usable).count();
+
+    serde_json::json!({
+        "config": {
+            "path": config_path.map(|p| p.display().to_string()),
+            "valid": true,
+            "default_profile": config.default_profile,
+            "user_profiles": config.profiles.len(),
+            "builtin_profiles": builtin_profiles().len(),
+            "warnings": config.warnings,
+        },
+        "adapters": rows,
+        "profiles": profiles,
+        "summary": {
+            "adapters_ready": ready.values().filter(|v| **v).count(),
+            "adapters_total": ready.len(),
+            "profiles_usable": usable_profiles,
+            "profiles_total": profiles.len(),
+        },
+    })
+}
+
+pub async fn run(args: DoctorArgs) -> anyhow::Result<()> {
+    // An explicit-but-invalid config is reported, not fatal: doctor exists to
+    // surface exactly that kind of problem.
+    let (config_path, config, config_error) = match council::load_config(args.config.as_deref()) {
+        Ok((path, config)) => (path, config, None),
+        Err(e) => (args.config.clone(), Config::default(), Some(e.to_string())),
+    };
+
+    let mut report = report(config_path, &config).await;
+    if let Some(error) = &config_error {
+        report["config"]["valid"] = serde_json::json!(false);
+        report["config"]["error"] = serde_json::json!(error);
+    }
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    // Human-readable rendering.
+    let config = &report["config"];
+    let valid = config["valid"].as_bool() == Some(true);
+    match (&config["path"], valid) {
+        (serde_json::Value::String(path), _) => println!("{} {path}", "Config:".bold()),
+        (_, true) => println!("{} none found (using defaults + built-ins)", "Config:".bold()),
+        (_, false) => println!("{} discovery failed", "Config:".bold()),
+    }
+    if valid {
+        let default = config["default_profile"].as_str().unwrap_or("none");
+        println!(
+            "  valid; default profile: {default}; user profiles: {}; built-ins: {}",
+            config["user_profiles"], config["builtin_profiles"]
+        );
+    } else {
+        println!("  {} {}", "✗".red(), config["error"].as_str().unwrap_or("invalid"));
+    }
+
+    println!("\n{}", "Adapters:".bold());
+    for row in report["adapters"].as_array().into_iter().flatten() {
+        let ready = row["ready"].as_bool().unwrap_or(false);
+        let mark = if ready { "✓".green() } else { "✗".red() };
+        let efforts = row["efforts"]
+            .as_array()
+            .map(|e| {
+                if e.is_empty() {
+                    "none".to_string()
+                } else {
+                    e.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(", ")
+                }
+            })
+            .unwrap_or_else(|| "none".to_string());
+        println!(
+            "  {mark} {:<9} {:<12} {:<12} {}",
+            row["id"].as_str().unwrap_or(""),
+            row["transport"].as_str().unwrap_or(""),
+            row["stability"].as_str().unwrap_or(""),
+            row["readiness"].as_str().unwrap_or(""),
+        );
+        println!("      efforts: {efforts}; {}", row["notes"].as_str().unwrap_or(""));
+    }
+
+    println!("\n{}", "Profiles:".bold());
+    for row in report["profiles"].as_array().into_iter().flatten() {
+        let usable = row["usable"].as_bool().unwrap_or(false);
+        let mark = if usable { "✓".green() } else { "✗".yellow() };
+        let kind = if row["builtin"].as_bool() == Some(true) { "built-in" } else { "user" };
+        println!(
+            "  {mark} {:<16} {:<8} strategy={} quorum={} ready={}/{}",
+            row["name"].as_str().unwrap_or(""),
+            kind,
+            row["strategy"].as_str().unwrap_or(""),
+            row["quorum"],
+            row["ready_members"],
+            row["members"],
+        );
+    }
+
+    let summary = &report["summary"];
+    println!(
+        "\n{} {}/{} adapters ready, {}/{} profiles usable",
+        "Summary:".bold(),
+        summary["adapters_ready"],
+        summary["adapters_total"],
+        summary["profiles_usable"],
+        summary["profiles_total"],
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_rows_count_ready_members_against_quorum() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.mixed]
+strategy = "judge"
+quorum = 1
+members = ["claude:opus@high", "codex:default@high"]
+"#,
+        )
+        .unwrap();
+        let ready = BTreeMap::from([("claude".to_string(), true), ("codex".to_string(), false)]);
+        let rows = profile_rows(&config, &ready);
+        let mixed = rows.iter().find(|r| r.name == "mixed").unwrap();
+        assert_eq!(mixed.members, 2);
+        assert_eq!(mixed.ready_members, 1);
+        assert!(mixed.usable); // quorum 1 is satisfied
+        assert!(!mixed.builtin);
+
+        // The built-in deep profile needs 3 ready members.
+        let deep = rows.iter().find(|r| r.name == "deep").unwrap();
+        assert!(deep.builtin);
+        assert_eq!(deep.quorum, 3);
+        assert!(!deep.usable);
+    }
+
+    #[test]
+    fn user_profile_shadowing_builtin_is_not_marked_builtin() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.deep]
+quorum = 1
+members = ["codex:default@high"]
+"#,
+        )
+        .unwrap();
+        let rows = profile_rows(&config, &BTreeMap::new());
+        let deep = rows.iter().find(|r| r.name == "deep").unwrap();
+        assert!(!deep.builtin);
+    }
+
+    #[test]
+    fn invalid_profiles_are_skipped_not_fatal() {
+        // resolve_profile failures (none expected post-validation, but be
+        // defensive) must not break the report.
+        let config = Config::default();
+        let rows = profile_rows(&config, &BTreeMap::new());
+        assert!(rows.iter().any(|r| r.name == "deep"));
+    }
+}

--- a/crates/caucus-cli/src/commands/mod.rs
+++ b/crates/caucus-cli/src/commands/mod.rs
@@ -1,7 +1,12 @@
 pub mod ask;
 pub mod bench;
 pub mod compare;
+pub mod council;
 pub mod debate;
+pub mod doctor;
+pub mod profiles;
+pub mod review;
+pub mod run;
 pub mod serve;
 
 use caucus_core::{HttpProvider, LlmProvider, MultiProvider};

--- a/crates/caucus-cli/src/commands/profiles.rs
+++ b/crates/caucus-cli/src/commands/profiles.rs
@@ -1,0 +1,169 @@
+//! `caucus profiles [NAME]`: list or show council profiles — built-ins plus
+//! user profiles — with exact `utility:model@effort` member strings.
+
+use std::path::PathBuf;
+
+use caucus_core::{Config, builtin_profiles};
+use clap::Args;
+use colored::Colorize;
+
+use super::council;
+
+#[derive(Args)]
+pub struct ProfilesArgs {
+    /// Show a single profile in detail (name or the configured default)
+    pub name: Option<String>,
+
+    /// Emit the listing as JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Path to a caucus config file (TOML)
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+}
+
+/// One profile in the listing, with resolved exact member strings.
+#[derive(Debug, Clone, serde::Serialize)]
+struct ProfileEntry {
+    name: String,
+    builtin: bool,
+    description: Option<String>,
+    strategy: String,
+    quorum: usize,
+    deadline_secs: Option<u64>,
+    request_timeout_secs: Option<u64>,
+    budget_usd: Option<f64>,
+    judge: Option<String>,
+    members: Vec<String>,
+}
+
+/// Resolve every listable profile (user profiles shadow built-ins). Pure so
+/// it is unit-testable.
+fn entries(config: &Config) -> Vec<ProfileEntry> {
+    config
+        .list_profiles()
+        .into_iter()
+        .filter_map(|(name, _)| {
+            let council = config.resolve_profile(Some(&name)).ok()?;
+            Some(ProfileEntry {
+                builtin: builtin_profiles().contains_key(&name)
+                    && !config.profiles.contains_key(&name),
+                description: council.description,
+                strategy: council.strategy,
+                quorum: council.quorum,
+                deadline_secs: council.deadline_secs,
+                request_timeout_secs: council.request_timeout_secs,
+                budget_usd: council.budget_usd,
+                judge: council.judge.as_ref().map(ToString::to_string),
+                members: council.members.iter().map(|m| m.to_string()).collect(),
+                name,
+            })
+        })
+        .collect()
+}
+
+fn render_entry(entry: &ProfileEntry) {
+    let kind = if entry.builtin { "built-in".dimmed() } else { "user".cyan() };
+    println!("{} {entry_name} [{kind}]", "●".green(), entry_name = entry.name.bold());
+    if let Some(description) = &entry.description {
+        println!("  {description}");
+    }
+    print!("  strategy={} quorum={}", entry.strategy, entry.quorum);
+    if let Some(deadline) = entry.deadline_secs {
+        print!(" deadline={deadline}s");
+    }
+    if let Some(timeout) = entry.request_timeout_secs {
+        print!(" request-timeout={timeout}s");
+    }
+    if let Some(budget) = entry.budget_usd {
+        print!(" budget=${budget:.2}");
+    }
+    if let Some(judge) = &entry.judge {
+        print!(" judge={judge}");
+    }
+    println!();
+    for member in &entry.members {
+        println!("    - {member}");
+    }
+}
+
+pub async fn run(args: ProfilesArgs) -> anyhow::Result<()> {
+    let (_path, config) = council::load_config(args.config.as_deref())?;
+    let all = entries(&config);
+
+    if let Some(name) = &args.name {
+        // `resolve_profile` gives the precise error for unknown names.
+        config.resolve_profile(Some(name))?;
+        let entry = all.into_iter().find(|e| e.name == *name).expect("resolved above");
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&entry)?);
+        } else {
+            render_entry(&entry);
+        }
+        return Ok(());
+    }
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&all)?);
+        return Ok(());
+    }
+
+    if let Some(default) = &config.default_profile {
+        println!("{} {default}\n", "Default profile:".bold());
+    }
+    for (i, entry) in all.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        render_entry(entry);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entries_have_exact_member_strings() {
+        let config = Config::from_toml_str(
+            r#"
+default_profile = "frontier"
+
+[profiles.frontier]
+description = "exact pins"
+strategy = "judge"
+quorum = 2
+deadline_secs = 300
+members = ["claude:claude-opus-4-6@xhigh", "kimi:kimi-code/k3@high"]
+"#,
+        )
+        .unwrap();
+        let all = entries(&config);
+        let frontier = all.iter().find(|e| e.name == "frontier").unwrap();
+        assert_eq!(
+            frontier.members,
+            vec!["claude:claude-opus-4-6@xhigh".to_string(), "kimi:kimi-code/k3@high".to_string()]
+        );
+        assert!(!frontier.builtin);
+        assert_eq!(frontier.strategy, "judge");
+        assert_eq!(frontier.quorum, 2);
+        assert_eq!(frontier.deadline_secs, Some(300));
+
+        // Built-in deep is present with its exact pins.
+        let deep = all.iter().find(|e| e.name == "deep").unwrap();
+        assert!(deep.builtin);
+        assert_eq!(deep.members.len(), 5);
+        assert_eq!(deep.members[0], "claude:opus@xhigh");
+    }
+
+    #[test]
+    fn entries_serialize_to_json() {
+        let config = Config::default();
+        let json = serde_json::to_value(entries(&config)).unwrap();
+        let deep = json.as_array().unwrap().iter().find(|e| e["name"] == "deep").unwrap();
+        assert_eq!(deep["builtin"], true);
+        assert_eq!(deep["members"][0], "claude:opus@xhigh");
+    }
+}

--- a/crates/caucus-cli/src/commands/review.rs
+++ b/crates/caucus-cli/src/commands/review.rs
@@ -1,0 +1,2320 @@
+//! `caucus review`: adjudicated multi-model code/text review.
+//!
+//! A narrow, fixed four-phase pipeline — not a generic DAG:
+//!
+//! 1. **Review** — every council member independently reviews the input and
+//!    returns findings under a strict JSON schema (direct JSON or fenced
+//!    blocks only; prose is never accepted as findings).
+//! 2. **Anonymize** — findings are assigned deterministic anonymous source
+//!    IDs so peer voting is blind.
+//! 3. **Vote** — every member casts schema-level support/oppose/abstain
+//!    votes with evidence-linked reasons over all anonymized findings.
+//! 4. **Adjudicate** — a council judge accepts or rejects each finding with
+//!    a reason citing the evidence and the raw votes.
+//!
+//! Accepted findings are classified `unanimous` / `majority` / `disputed`
+//! from the raw votes: unanimous only when every valid ballot supports,
+//! majority only when more than half of all valid ballots support. Partial
+//! failures are warnings; quorum is enforced on semantically valid parsed
+//! results in every LLM phase — transport successes that fail parsing or
+//! ballot validation never count. Parse failures are recorded honestly —
+//! votes and scores are never fabricated. Each phase checkpoints to a narrow
+//! versioned JSON state file (written atomically via temp file + rename);
+//! `--resume` validates the input/options hash and reuses completed phases.
+//! Git input is read via `ProcessSpec`/`run_argv` with an explicit argv,
+//! never a shell.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use caucus_core::provider::{FanoutReport, MultiProvider, fanout};
+use caucus_core::{
+    Config, Council, FanoutConfig, LlmProvider, ProcessLimits, ProcessOutput, ProcessSpec,
+    Transport, run_argv,
+};
+use clap::Args;
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::council;
+use crate::commands::run::RunDeadline;
+
+// ---------------------------------------------------------------------------
+// Deterministic FNV-1a 64-bit hashing (local, no new dependency)
+// ---------------------------------------------------------------------------
+
+/// FNV-1a 64-bit hash.
+pub fn fnv64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Lowercase hex rendering of [`fnv64`], zero-padded to 16 digits.
+pub fn fnv64_hex(bytes: &[u8]) -> String {
+    format!("{:016x}", fnv64(bytes))
+}
+
+// ---------------------------------------------------------------------------
+// CLI arguments
+// ---------------------------------------------------------------------------
+
+#[derive(Args)]
+pub struct ReviewArgs {
+    /// Review a single file (conflicts with --git-diff/--staged; default is stdin)
+    #[arg(long, conflicts_with_all = ["git_diff", "staged"])]
+    pub file: Option<PathBuf>,
+
+    /// Review the working-tree diff (`git diff`)
+    #[arg(long, conflicts_with = "staged")]
+    pub git_diff: bool,
+
+    /// Review the staged diff (`git diff --staged`)
+    #[arg(long)]
+    pub staged: bool,
+
+    /// Council profile name (defaults to configured default, then `deep`)
+    #[arg(long, conflicts_with = "auto")]
+    pub profile: Option<String>,
+
+    /// Use the zero-key auto council from locally discovered adapters
+    #[arg(long)]
+    pub auto: bool,
+
+    /// Path to config file
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Receipt format
+    #[arg(long, default_value = "markdown", value_parser = ["markdown", "json"])]
+    pub format: String,
+
+    /// Write the receipt to a file instead of stdout
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+
+    /// Write the provenance manifest (full receipt JSON) to this path;
+    /// the checkpoint state lives next to it
+    #[arg(long)]
+    pub manifest: Option<PathBuf>,
+
+    /// Resume from the checkpoint state, reusing completed phases
+    #[arg(long)]
+    pub resume: bool,
+
+    /// Minimum successful participants per LLM phase (default: profile quorum)
+    #[arg(long)]
+    pub quorum: Option<usize>,
+
+    /// Whole-run wall-clock deadline in seconds (default: profile deadline)
+    #[arg(long)]
+    pub deadline_secs: Option<u64>,
+
+    /// Per-provider request/process timeout in seconds
+    #[arg(long)]
+    pub request_timeout_secs: Option<u64>,
+
+    /// Maximum concurrent requests (default: 4)
+    #[arg(long)]
+    pub max_concurrency: Option<usize>,
+
+    /// Advisory budget in USD (recorded; not enforced — transports expose no cost data)
+    #[arg(long)]
+    pub budget_usd: Option<f64>,
+
+    /// Hard cap on total provider requests across all phases
+    #[arg(long)]
+    pub max_requests: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Strict finding / vote / adjudication schemas
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Severity::Low => "low",
+            Severity::Medium => "medium",
+            Severity::High => "high",
+            Severity::Critical => "critical",
+        };
+        f.write_str(s)
+    }
+}
+
+/// One finding as returned by a reviewing member. Strict: unknown fields and
+/// missing required fields are parse errors, never silently tolerated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawFinding {
+    pub title: String,
+    pub severity: Severity,
+    pub evidence: String,
+    #[serde(default)]
+    pub file: Option<String>,
+    #[serde(default)]
+    pub line: Option<u64>,
+    #[serde(default)]
+    pub recommendation: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FindingsDoc {
+    findings: Vec<RawFinding>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Vote {
+    Support,
+    Oppose,
+    Abstain,
+}
+
+impl std::fmt::Display for Vote {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Vote::Support => "support",
+            Vote::Oppose => "oppose",
+            Vote::Abstain => "abstain",
+        };
+        f.write_str(s)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoteCast {
+    pub finding_id: String,
+    pub vote: Vote,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VotesDoc {
+    votes: Vec<VoteCast>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Adjudication {
+    pub finding_id: String,
+    pub accepted: bool,
+    pub reason: String,
+    #[serde(default)]
+    pub evidence: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AdjudicationDoc {
+    adjudications: Vec<Adjudication>,
+}
+
+/// Accepted-finding classification derived from raw votes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Classification {
+    Unanimous,
+    Majority,
+    Disputed,
+}
+
+impl std::fmt::Display for Classification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Classification::Unanimous => "unanimous",
+            Classification::Majority => "majority",
+            Classification::Disputed => "disputed",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Classify from counted votes. `ballots` is the number of valid ballots
+/// cast; unparseable or schema-incomplete ballots are excluded upstream,
+/// never counted as abstain. Unanimous requires every valid ballot to
+/// support; majority requires support from more than half of all valid
+/// ballots (abstentions and omissions count as non-support); anything else
+/// is disputed.
+pub fn classify(support: usize, ballots: usize) -> Classification {
+    if ballots > 0 && support == ballots {
+        Classification::Unanimous
+    } else if support * 2 > ballots {
+        Classification::Majority
+    } else {
+        Classification::Disputed
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON extraction: direct documents and fenced blocks only — never prose
+// ---------------------------------------------------------------------------
+
+/// Candidate JSON texts: the whole trimmed response, then each fenced code
+/// block. Anything outside a fence is prose and is never parsed as findings.
+fn json_candidates(text: &str) -> Vec<String> {
+    let mut candidates = vec![text.trim().to_string()];
+    let mut rest = text;
+    while let Some(start) = rest.find("```") {
+        let after_open = &rest[start + 3..];
+        // Skip an optional language tag on the opening fence line.
+        let body_start = after_open.find('\n').map(|i| i + 1).unwrap_or(0);
+        let body = &after_open[body_start..];
+        match body.find("```") {
+            Some(end) => {
+                candidates.push(body[..end].trim().to_string());
+                rest = &body[end + 3..];
+            }
+            None => break,
+        }
+    }
+    candidates
+}
+
+/// Parse member findings: a `{"findings": [...]}` document or a bare array,
+/// either as the whole response or inside a fenced block. Prose-only
+/// responses are an honest error.
+pub fn parse_findings(text: &str) -> std::result::Result<Vec<RawFinding>, String> {
+    for candidate in json_candidates(text) {
+        if let Ok(doc) = serde_json::from_str::<FindingsDoc>(&candidate) {
+            return Ok(doc.findings);
+        }
+        if let Ok(array) = serde_json::from_str::<Vec<RawFinding>>(&candidate) {
+            return Ok(array);
+        }
+    }
+    Err("response contained no strict or fenced JSON findings document".to_string())
+}
+
+/// Parse one ballot: `{"votes": [...]}` only (direct or fenced).
+pub fn parse_votes(text: &str) -> std::result::Result<Vec<VoteCast>, String> {
+    for candidate in json_candidates(text) {
+        if let Ok(doc) = serde_json::from_str::<VotesDoc>(&candidate) {
+            return Ok(doc.votes);
+        }
+    }
+    Err("response contained no strict or fenced JSON votes document".to_string())
+}
+
+/// Parse judge adjudications: `{"adjudications": [...]}` only (direct or fenced).
+pub fn parse_adjudications(text: &str) -> std::result::Result<Vec<Adjudication>, String> {
+    for candidate in json_candidates(text) {
+        if let Ok(doc) = serde_json::from_str::<AdjudicationDoc>(&candidate) {
+            return Ok(doc.adjudications);
+        }
+    }
+    Err("judge response contained no strict or fenced JSON adjudications document".to_string())
+}
+
+fn validate_adjudications(
+    adjudications: &[Adjudication],
+    findings: &[AttributedFinding],
+) -> std::result::Result<(), String> {
+    let known: std::collections::HashSet<&str> =
+        findings.iter().map(|finding| finding.id.as_str()).collect();
+    let mut seen = std::collections::HashSet::new();
+    for adjudication in adjudications {
+        if !known.contains(adjudication.finding_id.as_str()) {
+            return Err(format!("unknown finding_id `{}`", adjudication.finding_id));
+        }
+        if !seen.insert(adjudication.finding_id.as_str()) {
+            return Err(format!("duplicate finding_id `{}`", adjudication.finding_id));
+        }
+    }
+    let missing: Vec<&str> = findings
+        .iter()
+        .map(|finding| finding.id.as_str())
+        .filter(|id| !seen.contains(id))
+        .collect();
+    if !missing.is_empty() {
+        return Err(format!("missing adjudications for {}", missing.join(", ")));
+    }
+    Ok(())
+}
+
+/// Deterministic anonymous source ID for a council member.
+pub fn anon_source_id(member: &str) -> String {
+    format!("src-{}", &fnv64_hex(member.as_bytes())[..8])
+}
+
+// ---------------------------------------------------------------------------
+// Input acquisition
+// ---------------------------------------------------------------------------
+
+/// Build the explicit git argv for diff input. Never a shell.
+pub fn git_diff_argv(staged: bool) -> Vec<String> {
+    let mut argv = vec!["git".to_string(), "diff".to_string()];
+    if staged {
+        argv.push("--staged".to_string());
+    }
+    argv
+}
+
+async fn read_git_diff(staged: bool) -> Result<String> {
+    let mut spec = ProcessSpec::new("git")
+        .arg("diff")
+        .inherit_env("GIT_DIR")
+        .inherit_env("GIT_WORK_TREE")
+        .inherit_env("GIT_INDEX_FILE")
+        .inherit_env("GIT_OBJECT_DIRECTORY")
+        .inherit_env("GIT_ALTERNATE_OBJECT_DIRECTORIES");
+    if staged {
+        spec = spec.arg("--staged");
+    }
+    let output = run_argv(&spec, &ProcessLimits::default())
+        .await
+        .with_context(|| format!("failed to run `{}`", git_diff_argv(staged).join(" ")))?;
+    complete_git_diff(output, &git_diff_argv(staged).join(" "))
+}
+
+fn complete_git_diff(output: ProcessOutput, command: &str) -> Result<String> {
+    if !output.success() {
+        anyhow::bail!("`{command}` exited with {:?}: {}", output.exit_code, output.stderr.trim());
+    }
+    if output.truncated {
+        anyhow::bail!(
+            "`{command}` exceeded the {}-byte capture limit; refusing to review an incomplete diff",
+            ProcessLimits::default().max_stdout_bytes
+        );
+    }
+    Ok(output.stdout)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputMeta {
+    pub source: String,
+    pub detail: String,
+    pub bytes: usize,
+    pub hash: String,
+}
+
+async fn acquire_input(args: &ReviewArgs) -> Result<(String, InputMeta)> {
+    let (content, source, detail) = if let Some(path) = &args.file {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        (content, "file", path.display().to_string())
+    } else if args.git_diff {
+        (read_git_diff(false).await?, "git-diff", git_diff_argv(false).join(" "))
+    } else if args.staged {
+        (read_git_diff(true).await?, "git-staged", git_diff_argv(true).join(" "))
+    } else {
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+            .context("failed to read stdin")?;
+        (buf, "stdin", "-".to_string())
+    };
+    if content.trim().is_empty() {
+        anyhow::bail!("nothing to review: {source} input is empty");
+    }
+    let meta =
+        InputMeta { source: source.to_string(), detail, bytes: content.len(), hash: String::new() };
+    Ok((content, meta))
+}
+
+// ---------------------------------------------------------------------------
+// Request budget enforcement (max_requests is a hard cap)
+// ---------------------------------------------------------------------------
+
+/// Wraps a provider with a shared request counter. Every admitted request
+/// increments the counter — capped or not — so the counter is always the
+/// receipt's request total. Requests beyond the cap fail honestly and are
+/// rolled back, never counted.
+struct BudgetedProvider {
+    inner: Arc<dyn LlmProvider>,
+    used: Arc<AtomicUsize>,
+    max: Option<usize>,
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for BudgetedProvider {
+    async fn complete(&self, prompt: &str, system: Option<&str>) -> Result<String> {
+        let prev = self.used.fetch_add(1, Ordering::SeqCst);
+        if let Some(max) = self.max
+            && prev >= max
+        {
+            self.used.fetch_sub(1, Ordering::SeqCst);
+            anyhow::bail!("request budget exhausted (--max-requests {max})");
+        }
+        self.inner.complete(prompt, system).await
+    }
+
+    fn transport(&self) -> Transport {
+        self.inner.transport()
+    }
+
+    fn options(&self) -> caucus_core::ProviderOptions {
+        self.inner.options()
+    }
+}
+
+fn wrap_with_budget(
+    base: &MultiProvider,
+    used: Arc<AtomicUsize>,
+    max: Option<usize>,
+) -> MultiProvider {
+    let mut multi = MultiProvider::new();
+    for (name, provider) in base.iter() {
+        let wrapped =
+            BudgetedProvider { inner: Arc::clone(provider), used: Arc::clone(&used), max };
+        multi = multi.add_shared(name.to_string(), Arc::new(wrapped));
+    }
+    multi
+}
+
+/// Wrap the judge's provider in the shared request budget. The judge is
+/// selected from the *unwrapped* council providers — or built dedicated when
+/// the designated judge is not a council member — so every adjudication
+/// request consumes the same hard budget as council members, exactly once.
+fn budgeted_judge(
+    base: &MultiProvider,
+    name: &str,
+    judge: council::JudgeProvider<'_>,
+    used: Arc<AtomicUsize>,
+    max: Option<usize>,
+) -> BudgetedProvider {
+    let inner: Arc<dyn LlmProvider> = match judge {
+        council::JudgeProvider::Borrowed(_) => {
+            base.get_shared(name).expect("borrowed judge is a registered council member")
+        }
+        council::JudgeProvider::Owned(provider) => Arc::from(provider),
+    };
+    BudgetedProvider { inner, used, max }
+}
+
+async fn complete_with_timeout(
+    provider: &dyn LlmProvider,
+    prompt: &str,
+    system: Option<&str>,
+    timeout: Duration,
+    label: &str,
+) -> Result<String> {
+    match tokio::time::timeout(timeout, provider.complete(prompt, system)).await {
+        Ok(result) => result,
+        Err(_) => Err(caucus_core::ProviderError::timeout(format!(
+            "{label} exceeded {}s request timeout",
+            timeout.as_secs()
+        ))
+        .into()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint state (narrow, versioned)
+// ---------------------------------------------------------------------------
+
+pub const CHECKPOINT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParticipantRecord {
+    pub member: String,
+    pub transport: String,
+    /// "ok" | "failed" | "parse-error" | "incomplete-ballot"
+    pub status: String,
+    pub latency_ms: u64,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttributedFinding {
+    /// Global deterministic ID (F1, F2, ...) in collection order.
+    pub id: String,
+    /// Anonymous source ID shown to peer voters.
+    pub source: String,
+    /// Originating member (provenance; hidden from voters).
+    pub member: String,
+    pub finding: RawFinding,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ballot {
+    pub voter: String,
+    pub votes: Vec<VoteCast>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Phase1State {
+    participants: Vec<ParticipantRecord>,
+    findings: Vec<AttributedFinding>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Phase3State {
+    participants: Vec<ParticipantRecord>,
+    ballots: Vec<Ballot>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Phase4State {
+    judge: ParticipantRecord,
+    adjudications: Vec<Adjudication>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Checkpoint {
+    pub version: u32,
+    pub run_id: String,
+    pub input_hash: String,
+    pub options_hash: String,
+    /// Provider requests admitted so far across all phases; the resume seed.
+    #[serde(default)]
+    pub requests_used: usize,
+    #[serde(default)]
+    phase1: Option<Phase1State>,
+    #[serde(default)]
+    phase3: Option<Phase3State>,
+    #[serde(default)]
+    phase4: Option<Phase4State>,
+}
+
+impl Checkpoint {
+    fn fresh(run_id: String, input_hash: String, options_hash: String) -> Self {
+        Self {
+            version: CHECKPOINT_VERSION,
+            run_id,
+            input_hash,
+            options_hash,
+            requests_used: 0,
+            phase1: None,
+            phase3: None,
+            phase4: None,
+        }
+    }
+}
+
+/// Checkpoint lives next to the manifest, or in the cwd by default.
+pub fn checkpoint_path(manifest: Option<&Path>) -> PathBuf {
+    match manifest {
+        Some(p) => {
+            let mut s = p.as_os_str().to_owned();
+            s.push(".checkpoint.json");
+            PathBuf::from(s)
+        }
+        None => PathBuf::from(".caucus-review.checkpoint.json"),
+    }
+}
+
+/// Write `contents` to `path` atomically: write a sibling temp file, then
+/// rename it over `path`. The rename is atomic on the same filesystem, so an
+/// interruption can leave at most a stale temp file — never a partially
+/// written resume/manifest file at `path`.
+fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    let mut tmp_os = path.as_os_str().to_owned();
+    tmp_os.push(format!(".tmp-{}", std::process::id()));
+    let tmp = PathBuf::from(tmp_os);
+    std::fs::write(&tmp, contents)?;
+    std::fs::rename(&tmp, path)
+}
+
+fn save_checkpoint(path: &Path, checkpoint: &Checkpoint) -> Result<()> {
+    let json = serde_json::to_string_pretty(checkpoint)?;
+    write_atomic(path, &json)
+        .with_context(|| format!("failed to write checkpoint {}", path.display()))
+}
+
+fn load_checkpoint(path: &Path) -> Result<Checkpoint> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("--resume given but no checkpoint at {}", path.display()))?;
+    let checkpoint: Checkpoint = serde_json::from_str(&text)
+        .with_context(|| format!("checkpoint {} is not valid state JSON", path.display()))?;
+    if checkpoint.version != CHECKPOINT_VERSION {
+        anyhow::bail!(
+            "checkpoint version {} is not supported (expected {CHECKPOINT_VERSION})",
+            checkpoint.version
+        );
+    }
+    Ok(checkpoint)
+}
+
+// ---------------------------------------------------------------------------
+// Receipt
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MemberEntry {
+    pub member: String,
+    pub utility: String,
+    pub model: String,
+    pub effort: Option<String>,
+    pub transport: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ManifestSection {
+    pub profile: String,
+    pub options: OptionsSection,
+    pub members: Vec<MemberEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OptionsSection {
+    pub quorum: usize,
+    pub deadline_secs: Option<u64>,
+    pub request_timeout_secs: Option<u64>,
+    pub max_concurrency: usize,
+    pub budget_usd: Option<f64>,
+    pub max_requests: Option<usize>,
+    pub options_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReceiptVote {
+    pub voter: String,
+    pub vote: Vote,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReceiptFinding {
+    pub id: String,
+    pub title: String,
+    pub severity: Severity,
+    pub file: Option<String>,
+    pub line: Option<u64>,
+    pub evidence: String,
+    pub recommendation: Option<String>,
+    pub source: String,
+    pub member: String,
+    pub votes: Vec<ReceiptVote>,
+    pub dissent: Vec<ReceiptVote>,
+    pub adjudication: Option<Adjudication>,
+    pub classification: Option<Classification>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PhasesSection {
+    pub review: Vec<ParticipantRecord>,
+    pub voting: Vec<ParticipantRecord>,
+    pub adjudication: Option<ParticipantRecord>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestsSection {
+    pub used: usize,
+    pub max: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReviewReceipt {
+    pub schema: u32,
+    pub run_id: String,
+    pub input: InputMeta,
+    pub manifest: ManifestSection,
+    pub phases: PhasesSection,
+    pub findings: Vec<ReceiptFinding>,
+    pub warnings: Vec<String>,
+    pub budget_usd: Option<f64>,
+    pub budget_note: Option<String>,
+    pub deadline_secs: Option<u64>,
+    pub request_timeout_secs: Option<u64>,
+    pub requests: RequestsSection,
+    pub resumed: bool,
+}
+
+pub fn render_markdown(receipt: &ReviewReceipt) -> String {
+    let mut out = String::new();
+    out.push_str("# Caucus Review Receipt\n\n");
+    out.push_str(&format!("- Run: `{}`\n", receipt.run_id));
+    out.push_str(&format!(
+        "- Input: {} (`{}`), {} bytes, hash `{}`\n",
+        receipt.input.source, receipt.input.detail, receipt.input.bytes, receipt.input.hash
+    ));
+    out.push_str(&format!(
+        "- Profile: `{}` (quorum {}, concurrency {})\n",
+        receipt.manifest.profile,
+        receipt.manifest.options.quorum,
+        receipt.manifest.options.max_concurrency
+    ));
+    if let Some(deadline) = receipt.deadline_secs {
+        out.push_str(&format!("- Whole-run deadline: {deadline}s\n"));
+    }
+    if let Some(timeout) = receipt.request_timeout_secs {
+        out.push_str(&format!("- Per-request timeout: {timeout}s\n"));
+    }
+    match (receipt.budget_usd, &receipt.budget_note) {
+        (Some(b), _) => out.push_str(&format!("- Budget: ${b:.2} (advisory — not enforced)\n")),
+        (None, Some(note)) => out.push_str(&format!("- Budget: {note}\n")),
+        (None, None) => {}
+    }
+    match receipt.requests.max {
+        Some(max) => {
+            out.push_str(&format!("- Requests: {}/{max} used\n", receipt.requests.used));
+        }
+        None => out.push_str(&format!("- Requests: {} used (no cap)\n", receipt.requests.used)),
+    }
+    if receipt.resumed {
+        out.push_str("- Resumed: yes (completed phases reused from checkpoint)\n");
+    }
+
+    out.push_str("\n## Members\n\n");
+    for m in &receipt.manifest.members {
+        let effort = m.effort.as_deref().unwrap_or("-");
+        out.push_str(&format!(
+            "- `{}` — utility `{}`, model `{}`, effort `{}`, transport `{}`\n",
+            m.member, m.utility, m.model, effort, m.transport
+        ));
+    }
+
+    out.push_str("\n## Phase participants\n\n");
+    for (name, records) in [("review", &receipt.phases.review), ("voting", &receipt.phases.voting)]
+    {
+        out.push_str(&format!("### {name}\n\n"));
+        for p in records {
+            match &p.error {
+                Some(err) => out.push_str(&format!(
+                    "- `{}`: {} ({} ms) — {}\n",
+                    p.member, p.status, p.latency_ms, err
+                )),
+                None => {
+                    out.push_str(&format!("- `{}`: {} ({} ms)\n", p.member, p.status, p.latency_ms))
+                }
+            }
+        }
+        out.push('\n');
+    }
+    if let Some(judge) = &receipt.phases.adjudication {
+        out.push_str("### adjudication\n\n");
+        match &judge.error {
+            Some(err) => out.push_str(&format!(
+                "- `{}`: {} ({} ms) — {}\n",
+                judge.member, judge.status, judge.latency_ms, err
+            )),
+            None => out.push_str(&format!(
+                "- `{}`: {} ({} ms)\n",
+                judge.member, judge.status, judge.latency_ms
+            )),
+        }
+    }
+
+    out.push_str("\n## Findings\n\n");
+    if receipt.findings.is_empty() {
+        out.push_str("No findings.\n");
+    }
+    for f in &receipt.findings {
+        let location = match (&f.file, f.line) {
+            (Some(file), Some(line)) => format!(" ({file}:{line})"),
+            (Some(file), None) => format!(" ({file})"),
+            (None, _) => String::new(),
+        };
+        let verdict = match (&f.adjudication, f.classification) {
+            (Some(a), Some(c)) if a.accepted => format!("accepted — {c}"),
+            (Some(a), None) if !a.accepted => "rejected".to_string(),
+            _ => "not adjudicated".to_string(),
+        };
+        out.push_str(&format!("### {} [{}]{} — {}\n\n", f.id, f.severity, location, verdict));
+        out.push_str(&format!("{}\n\n", f.title));
+        out.push_str(&format!("- Evidence: {}\n", f.evidence));
+        if let Some(rec) = &f.recommendation {
+            out.push_str(&format!("- Recommendation: {rec}\n"));
+        }
+        out.push_str(&format!("- Source: `{}` (member `{}`)\n", f.source, f.member));
+        if let Some(a) = &f.adjudication {
+            out.push_str(&format!("- Adjudication: {}\n", a.reason));
+            if let Some(ev) = &a.evidence {
+                out.push_str(&format!("- Adjudication evidence: {ev}\n"));
+            }
+        }
+        if !f.votes.is_empty() {
+            out.push_str("- Votes:\n");
+            for v in &f.votes {
+                let reason = v.reason.as_deref().unwrap_or("-");
+                out.push_str(&format!("  - `{}`: {} — {}\n", v.voter, v.vote, reason));
+            }
+        }
+        if !f.dissent.is_empty() {
+            out.push_str("- Dissent:\n");
+            for v in &f.dissent {
+                let reason = v.reason.as_deref().unwrap_or("-");
+                out.push_str(&format!("  - `{}`: {} — {}\n", v.voter, v.vote, reason));
+            }
+        }
+        out.push('\n');
+    }
+
+    if !receipt.warnings.is_empty() {
+        out.push_str("## Warnings\n\n");
+        for w in &receipt.warnings {
+            out.push_str(&format!("- {w}\n"));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
+const REVIEW_SYSTEM: &str = "You are a meticulous code reviewer. Respond with ONLY a JSON object \
+of the form {\"findings\": [{\"title\": string, \"severity\": \"low\"|\"medium\"|\"high\"|\"critical\", \
+\"evidence\": string, \"file\": string|null, \"line\": number|null, \"recommendation\": string|null}]}. \
+Evidence must quote or precisely reference the reviewed material. No prose, no markdown fences. \
+If there are no findings, return {\"findings\": []}.";
+
+const VOTE_SYSTEM: &str = "You are a blind peer reviewer voting on anonymized findings. For each \
+finding, cast exactly one vote: \"support\", \"oppose\", or \"abstain\". Respond with ONLY a JSON \
+object {\"votes\": [{\"finding_id\": string, \"vote\": \"support\"|\"oppose\"|\"abstain\", \
+\"reason\": string}]}. Reasons must cite the finding's evidence. No prose, no markdown fences.";
+
+const JUDGE_SYSTEM: &str = "You are the adjudicating judge of a code review council. You receive \
+findings and the raw anonymized peer votes. For each finding decide accepted (true/false) with a \
+reason that cites the finding's evidence and the votes. Respond with ONLY a JSON object \
+{\"adjudications\": [{\"finding_id\": string, \"accepted\": boolean, \"reason\": string, \
+\"evidence\": string|null}]}. No prose, no markdown fences.";
+
+fn review_prompt(source_detail: &str, content: &str) -> String {
+    format!(
+        "Review the following material from {source_detail}. Report only concrete, \
+         evidence-backed defects, risks, or correctness issues.\n\n\
+         --- BEGIN MATERIAL ---\n{content}\n--- END MATERIAL ---"
+    )
+}
+
+fn vote_prompt(findings: &[AttributedFinding]) -> String {
+    let anonymized: Vec<serde_json::Value> = findings
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "id": f.id,
+                "source": f.source,
+                "title": f.finding.title,
+                "severity": f.finding.severity,
+                "file": f.finding.file,
+                "line": f.finding.line,
+                "evidence": f.finding.evidence,
+                "recommendation": f.finding.recommendation,
+            })
+        })
+        .collect();
+    format!(
+        "Vote on every finding below. You must cast one vote per finding ID.\n\n{}",
+        serde_json::to_string_pretty(&anonymized).expect("findings serialize")
+    )
+}
+
+fn judge_prompt(findings: &[AttributedFinding], ballots: &[Ballot]) -> String {
+    let anonymized: Vec<serde_json::Value> = findings
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "id": f.id,
+                "source": f.source,
+                "title": f.finding.title,
+                "severity": f.finding.severity,
+                "file": f.finding.file,
+                "line": f.finding.line,
+                "evidence": f.finding.evidence,
+            })
+        })
+        .collect();
+    let votes: Vec<serde_json::Value> = ballots
+        .iter()
+        .map(|b| {
+            serde_json::json!({
+                "voter": anon_source_id(&b.voter),
+                "votes": b.votes,
+            })
+        })
+        .collect();
+    format!(
+        "Adjudicate every finding. Findings:\n{}\n\nRaw votes:\n{}",
+        serde_json::to_string_pretty(&anonymized).expect("findings serialize"),
+        serde_json::to_string_pretty(&votes).expect("votes serialize"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Phase helpers
+// ---------------------------------------------------------------------------
+
+/// A transport-successful response that did not yield a semantically valid
+/// phase result: unparseable JSON, or a schema-incomplete ballot. Recorded
+/// honestly; never counted toward quorum, votes, or classification.
+#[derive(Debug)]
+struct InvalidResponse {
+    model: String,
+    /// Participant status: "parse-error" | "incomplete-ballot".
+    status: &'static str,
+    error: String,
+}
+
+fn participant_records(
+    report: &FanoutReport,
+    invalid: &[InvalidResponse],
+) -> Vec<ParticipantRecord> {
+    let mut records: Vec<ParticipantRecord> = report
+        .successes
+        .iter()
+        .map(|s| {
+            let problem = invalid.iter().find(|i| i.model == s.model);
+            ParticipantRecord {
+                member: s.model.clone(),
+                transport: s.transport.to_string(),
+                status: problem.map(|i| i.status.to_string()).unwrap_or_else(|| "ok".to_string()),
+                latency_ms: s.latency_ms,
+                error: problem.map(|i| i.error.clone()),
+            }
+        })
+        .collect();
+    records.extend(report.failures.iter().map(|f| ParticipantRecord {
+        member: f.model.clone(),
+        transport: f.transport.to_string(),
+        status: "failed".to_string(),
+        latency_ms: f.latency_ms,
+        error: Some(format!("{}: {}", f.kind, f.message)),
+    }));
+    records
+}
+
+/// Quorum is semantic: only responses that parsed into a valid phase result
+/// count — a findings document (possibly with zero findings) in review, a
+/// complete ballot in voting. Transport successes that fail parsing or
+/// ballot validation never satisfy quorum.
+fn enforce_quorum(phase: &str, valid: usize, quorum: usize) -> Result<()> {
+    if valid >= quorum {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "quorum not met in {phase} phase: {valid}/{quorum} required member(s) produced a valid response"
+    )
+}
+
+/// Parse every transport-successful review response into attributed findings.
+/// Returns the findings, the number of semantically valid responses (a valid
+/// document with zero findings counts), the invalid responses with
+/// phase-correct errors, and per-response warnings.
+fn collect_findings(
+    report: &FanoutReport,
+) -> (Vec<AttributedFinding>, usize, Vec<InvalidResponse>, Vec<String>) {
+    let mut findings: Vec<AttributedFinding> = Vec::new();
+    let mut invalid: Vec<InvalidResponse> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+    for success in &report.successes {
+        match parse_findings(&success.content) {
+            Ok(raw) => {
+                for finding in raw {
+                    let id = format!("F{}", findings.len() + 1);
+                    findings.push(AttributedFinding {
+                        id,
+                        source: anon_source_id(&success.model),
+                        member: success.model.clone(),
+                        finding,
+                    });
+                }
+            }
+            Err(e) => {
+                invalid.push(InvalidResponse {
+                    model: success.model.clone(),
+                    status: "parse-error",
+                    error: format!("response was not valid findings JSON: {e}"),
+                });
+                warnings.push(format!(
+                    "review: {} returned no valid findings JSON: {e}",
+                    success.model
+                ));
+            }
+        }
+    }
+    let valid = report.successes.len() - invalid.len();
+    (findings, valid, invalid, warnings)
+}
+
+/// Validate a parsed ballot against the known finding IDs: exactly one vote
+/// per known finding, no duplicates, no unknown IDs. Returns the votes in
+/// cast order on success, or the list of problems on failure.
+fn validate_ballot(
+    votes: &[VoteCast],
+    known: &std::collections::HashSet<&str>,
+) -> std::result::Result<Vec<VoteCast>, Vec<String>> {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut problems: Vec<String> = Vec::new();
+    let mut valid: Vec<VoteCast> = Vec::new();
+    for vote in votes {
+        if !known.contains(vote.finding_id.as_str()) {
+            problems.push(format!("vote for unknown finding `{}`", vote.finding_id));
+        } else if !seen.insert(vote.finding_id.as_str()) {
+            problems.push(format!("duplicate vote for `{}`", vote.finding_id));
+        } else {
+            valid.push(vote.clone());
+        }
+    }
+    let mut missing: Vec<&str> = known.iter().copied().filter(|id| !seen.contains(id)).collect();
+    missing.sort_unstable();
+    if !missing.is_empty() {
+        problems.push(format!("missing vote(s) for {}", missing.join(", ")));
+    }
+    if problems.is_empty() { Ok(valid) } else { Err(problems) }
+}
+
+/// Parse every transport-successful voting response into a ballot. A ballot
+/// is valid only when it casts exactly one vote for every known finding — no
+/// missing findings, no duplicates, no unknown IDs. Invalid ballots are
+/// recorded honestly and never counted toward quorum or classification.
+fn collect_ballots(
+    report: &FanoutReport,
+    known: &std::collections::HashSet<&str>,
+) -> (Vec<Ballot>, Vec<InvalidResponse>, Vec<String>) {
+    let mut ballots: Vec<Ballot> = Vec::new();
+    let mut invalid: Vec<InvalidResponse> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+    for success in &report.successes {
+        match parse_votes(&success.content) {
+            Ok(votes) => match validate_ballot(&votes, known) {
+                Ok(valid) => {
+                    ballots.push(Ballot { voter: success.model.clone(), votes: valid });
+                }
+                Err(problems) => {
+                    invalid.push(InvalidResponse {
+                        model: success.model.clone(),
+                        status: "incomplete-ballot",
+                        error: format!("ballot discarded: {}", problems.join("; ")),
+                    });
+                    warnings.push(format!(
+                        "voting: {} cast an incomplete ballot ({}); discarded",
+                        success.model,
+                        problems.join("; ")
+                    ));
+                }
+            },
+            Err(e) => {
+                // Honest handling: the ballot is missing, never fabricated.
+                invalid.push(InvalidResponse {
+                    model: success.model.clone(),
+                    status: "parse-error",
+                    error: format!("response was not valid votes JSON: {e}"),
+                });
+                warnings
+                    .push(format!("voting: {} returned no valid votes JSON: {e}", success.model));
+            }
+        }
+    }
+    (ballots, invalid, warnings)
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub async fn run(args: ReviewArgs) -> Result<()> {
+    let (_path, config) = council::load_config(args.config.as_deref())?;
+
+    // Profile: explicit flag, then configured default, then built-in `deep`.
+    let mut council: Council = if args.auto {
+        let selection = council::auto_council(&config).await;
+        for exclusion in &selection.exclusions {
+            eprintln!("  {} {} excluded: {}", "·".dimmed(), exclusion.adapter, exclusion.reason);
+        }
+        selection.council
+    } else if let Some(name) = args.profile.as_deref() {
+        config.resolve_profile(Some(name))?
+    } else {
+        match config.resolve_profile(None) {
+            Ok(c) => c,
+            Err(_) => config.resolve_profile(Some("deep"))?,
+        }
+    };
+    if council.members.is_empty() {
+        anyhow::bail!(
+            "council '{}' is empty — no members to run a review; run `caucus doctor` for details",
+            council.name
+        );
+    }
+
+    let quorum = args.quorum.unwrap_or(council.quorum);
+    if quorum == 0 || quorum > council.members.len() {
+        anyhow::bail!(
+            "quorum {quorum} is invalid for council '{}' with {} member(s)",
+            council.name,
+            council.members.len()
+        );
+    }
+    let deadline_secs = args.deadline_secs.or(council.deadline_secs);
+    let request_timeout_secs =
+        args.request_timeout_secs.or(council.request_timeout_secs).or(deadline_secs);
+    if deadline_secs == Some(0) {
+        anyhow::bail!("--deadline-secs must be at least 1");
+    }
+    if request_timeout_secs == Some(0) {
+        anyhow::bail!("--request-timeout-secs must be at least 1");
+    }
+    // Provider construction must see CLI-level overrides too, not only the
+    // original profile values. Outer fan-out/judge timeouts remain the final
+    // cancellation boundary.
+    council.deadline_secs = deadline_secs;
+    council.request_timeout_secs = request_timeout_secs;
+    let max_concurrency = args.max_concurrency.unwrap_or(4).max(1);
+    let budget_usd = args.budget_usd.or(council.budget_usd);
+    let max_requests = args.max_requests;
+
+    let (content, mut input) = acquire_input(&args).await?;
+    input.hash = fnv64_hex(content.as_bytes());
+
+    // Deterministic run identity: input + resolved options.
+    let members: Vec<String> = council.members.iter().map(|m| m.to_string()).collect();
+    let fingerprint = serde_json::json!({
+        "profile": council.name,
+        "members": members,
+        "quorum": quorum,
+        "deadline_secs": deadline_secs,
+        "request_timeout_secs": request_timeout_secs,
+        "max_concurrency": max_concurrency,
+        "budget_usd": budget_usd,
+        "max_requests": max_requests,
+    });
+    let options_hash = fnv64_hex(fingerprint.to_string().as_bytes());
+    let run_id = fnv64_hex(format!("{}:{}", input.hash, options_hash).as_bytes());
+
+    let ckpt_path = checkpoint_path(args.manifest.as_deref());
+    let mut checkpoint = if args.resume {
+        let loaded = load_checkpoint(&ckpt_path)?;
+        if loaded.input_hash != input.hash || loaded.options_hash != options_hash {
+            anyhow::bail!(
+                "checkpoint {} does not match this run (input or options changed); \
+                 refusing to resume",
+                ckpt_path.display()
+            );
+        }
+        eprintln!(
+            "{} Resuming run {} from {}",
+            "▶".green(),
+            loaded.run_id.cyan(),
+            ckpt_path.display()
+        );
+        loaded
+    } else {
+        Checkpoint::fresh(run_id.clone(), input.hash.clone(), options_hash.clone())
+    };
+    let resumed = args.resume;
+    let run_deadline = RunDeadline::new(deadline_secs);
+
+    let base = council::build_council_provider(&council, &config)?;
+    // A resumed run continues the checkpoint's cumulative request total so
+    // the hard cap spans both runs and the receipt reports the true total.
+    let request_count = Arc::new(AtomicUsize::new(checkpoint.requests_used));
+    let multi = wrap_with_budget(&base, Arc::clone(&request_count), max_requests);
+    let requested_timeout = Duration::from_secs(
+        request_timeout_secs.unwrap_or(caucus_core::DEFAULT_REQUEST_TIMEOUT.as_secs()),
+    );
+
+    let mut warnings: Vec<String> = Vec::new();
+    if budget_usd.is_some() {
+        warnings.push(
+            "budget_usd is advisory: current transports expose no cost data; recorded but not enforced"
+                .to_string(),
+        );
+    }
+
+    eprintln!(
+        "{} Review run {} — council '{}' ({} member(s), quorum {})",
+        "▶".green(),
+        run_id.cyan(),
+        council.name.cyan(),
+        council.members.len(),
+        quorum,
+    );
+
+    // -- Phase 1+2: independent reviews, then deterministic anonymization.
+    let phase1 = match checkpoint.phase1.clone() {
+        Some(state) => {
+            eprintln!("  {} review phase reused from checkpoint", "·".dimmed());
+            state
+        }
+        None => {
+            let timeout = run_deadline.turn_timeout(requested_timeout)?;
+            let report = run_deadline
+                .wait(fanout(
+                    &multi,
+                    &review_prompt(&input.detail, &content),
+                    Some(REVIEW_SYSTEM),
+                    FanoutConfig { max_concurrency, timeout, quorum },
+                ))
+                .await?;
+            for warning in report.warnings() {
+                eprintln!("  {} {}", "✗".red(), warning);
+                warnings.push(format!("review: {warning}"));
+            }
+            let (findings, valid, invalid, parse_warnings) = collect_findings(&report);
+            warnings.extend(parse_warnings);
+            for i in &invalid {
+                eprintln!("  {} {} — {}", "✗".red(), i.model, i.error);
+            }
+            // Quorum counts semantically valid responses only: unparseable
+            // responses never satisfy it, an empty findings document does.
+            enforce_quorum("review", valid, quorum)?;
+
+            let state = Phase1State {
+                participants: participant_records(&report, &invalid),
+                findings,
+                warnings: warnings.clone(),
+            };
+            checkpoint.phase1 = Some(state.clone());
+            checkpoint.requests_used = request_count.load(Ordering::SeqCst);
+            save_checkpoint(&ckpt_path, &checkpoint)?;
+            eprintln!(
+                "  {} review phase: {} finding(s) from {} valid response(s)",
+                "✓".green(),
+                state.findings.len(),
+                valid
+            );
+            state
+        }
+    };
+    for w in phase1.warnings.clone() {
+        if !warnings.contains(&w) {
+            warnings.push(w);
+        }
+    }
+
+    // -- Phase 3: blind peer voting (skipped when there is nothing to vote on).
+    let phase3 = if phase1.findings.is_empty() {
+        warnings.push("no findings produced; voting and adjudication skipped".to_string());
+        None
+    } else {
+        let state = match checkpoint.phase3.clone() {
+            Some(state) => {
+                eprintln!("  {} voting phase reused from checkpoint", "·".dimmed());
+                state
+            }
+            None => {
+                let timeout = run_deadline.turn_timeout(requested_timeout)?;
+                let report = run_deadline
+                    .wait(fanout(
+                        &multi,
+                        &vote_prompt(&phase1.findings),
+                        Some(VOTE_SYSTEM),
+                        FanoutConfig { max_concurrency, timeout, quorum },
+                    ))
+                    .await?;
+                for warning in report.warnings() {
+                    eprintln!("  {} {}", "✗".red(), warning);
+                    warnings.push(format!("voting: {warning}"));
+                }
+                let known: std::collections::HashSet<&str> =
+                    phase1.findings.iter().map(|f| f.id.as_str()).collect();
+                let (ballots, invalid, parse_warnings) = collect_ballots(&report, &known);
+                warnings.extend(parse_warnings);
+                for i in &invalid {
+                    eprintln!("  {} {} — {}", "✗".red(), i.model, i.error);
+                }
+                // Quorum counts complete ballots only: unparseable or
+                // schema-incomplete ballots never satisfy it.
+                enforce_quorum("voting", ballots.len(), quorum)?;
+
+                let state = Phase3State {
+                    participants: participant_records(&report, &invalid),
+                    ballots,
+                    warnings: warnings.clone(),
+                };
+                checkpoint.phase3 = Some(state.clone());
+                checkpoint.requests_used = request_count.load(Ordering::SeqCst);
+                save_checkpoint(&ckpt_path, &checkpoint)?;
+                eprintln!(
+                    "  {} voting phase: {} valid ballot(s)",
+                    "✓".green(),
+                    state.ballots.len()
+                );
+                state
+            }
+        };
+        Some(state)
+    };
+    if let Some(state) = &phase3 {
+        for warning in &state.warnings {
+            if !warnings.contains(warning) {
+                warnings.push(warning.clone());
+            }
+        }
+    }
+
+    // -- Phase 4: judge adjudication.
+    let phase4 = match &phase3 {
+        None => None,
+        Some(p3) => {
+            let state = match checkpoint.phase4.clone() {
+                Some(state) => {
+                    eprintln!("  {} adjudication reused from checkpoint", "·".dimmed());
+                    state
+                }
+                None => {
+                    // The profile's designated judge when set, otherwise the
+                    // first council member (long-standing default). Selected
+                    // from the unwrapped base providers and wrapped here, so
+                    // an external designated judge consumes the same hard
+                    // request budget as every council member.
+                    let (judge_name, judge) = council::select_judge(&council, &base, &config)?;
+                    let judge = budgeted_judge(
+                        &base,
+                        &judge_name,
+                        judge,
+                        Arc::clone(&request_count),
+                        max_requests,
+                    );
+                    let started = std::time::Instant::now();
+                    let timeout = run_deadline.turn_timeout(requested_timeout)?;
+                    let prompt = judge_prompt(&phase1.findings, &p3.ballots);
+                    let result = run_deadline
+                        .wait(complete_with_timeout(
+                            &judge,
+                            &prompt,
+                            Some(JUDGE_SYSTEM),
+                            timeout,
+                            &format!("judge `{judge_name}`"),
+                        ))
+                        .await?;
+                    let latency_ms = started.elapsed().as_millis() as u64;
+                    let state = match result {
+                        Ok(text) => match parse_adjudications(&text).and_then(|adjudications| {
+                            validate_adjudications(&adjudications, &phase1.findings)?;
+                            Ok(adjudications)
+                        }) {
+                            Ok(adjudications) => Phase4State {
+                                judge: ParticipantRecord {
+                                    member: judge_name.clone(),
+                                    transport: judge.transport().to_string(),
+                                    status: "ok".to_string(),
+                                    latency_ms,
+                                    error: None,
+                                },
+                                adjudications,
+                            },
+                            Err(e) => anyhow::bail!(
+                                "judge `{judge_name}` returned unparseable adjudications: {e} — \
+                                 refusing to fabricate a verdict",
+                            ),
+                        },
+                        Err(e) => anyhow::bail!("judge `{judge_name}` failed: {e}"),
+                    };
+                    checkpoint.phase4 = Some(state.clone());
+                    checkpoint.requests_used = request_count.load(Ordering::SeqCst);
+                    save_checkpoint(&ckpt_path, &checkpoint)?;
+                    eprintln!(
+                        "  {} adjudication: {} decision(s)",
+                        "✓".green(),
+                        state.adjudications.len()
+                    );
+                    state
+                }
+            };
+            Some(state)
+        }
+    };
+
+    // -- Assemble the receipt.
+    let ballot_count = phase3.as_ref().map(|p| p.ballots.len()).unwrap_or(0);
+    let findings: Vec<ReceiptFinding> = phase1
+        .findings
+        .iter()
+        .map(|af| {
+            let votes: Vec<ReceiptVote> = phase3
+                .as_ref()
+                .map(|p| {
+                    p.ballots
+                        .iter()
+                        .flat_map(|b| {
+                            b.votes.iter().filter(|v| v.finding_id == af.id).map(|v| ReceiptVote {
+                                voter: b.voter.clone(),
+                                vote: v.vote,
+                                reason: v.reason.clone(),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let support = votes.iter().filter(|v| v.vote == Vote::Support).count();
+            let oppose = votes.iter().filter(|v| v.vote == Vote::Oppose).count();
+            let abstain = votes.iter().filter(|v| v.vote == Vote::Abstain).count();
+            let cast = support + oppose + abstain;
+
+            let adjudication = phase4
+                .as_ref()
+                .and_then(|p| p.adjudications.iter().find(|a| a.finding_id == af.id).cloned());
+            let classification = match &adjudication {
+                Some(a) if a.accepted => Some(classify(support, cast)),
+                _ => None,
+            };
+            let dissent: Vec<ReceiptVote> = if classification.is_some() {
+                votes.iter().filter(|v| v.vote != Vote::Support).cloned().collect()
+            } else {
+                Vec::new()
+            };
+            ReceiptFinding {
+                id: af.id.clone(),
+                title: af.finding.title.clone(),
+                severity: af.finding.severity,
+                file: af.finding.file.clone(),
+                line: af.finding.line,
+                evidence: af.finding.evidence.clone(),
+                recommendation: af.finding.recommendation.clone(),
+                source: af.source.clone(),
+                member: af.member.clone(),
+                votes,
+                dissent,
+                adjudication,
+                classification,
+            }
+        })
+        .collect();
+
+    // Findings the judge never mentioned are honest non-decisions.
+    if let Some(p4) = &phase4 {
+        for f in &findings {
+            if f.adjudication.is_none() {
+                warnings.push(format!(
+                    "adjudication: judge returned no decision for {}; recorded as not adjudicated",
+                    f.id
+                ));
+            }
+        }
+        let _ = p4;
+    }
+    let _ = ballot_count;
+
+    let member_entries: Vec<MemberEntry> = council
+        .members
+        .iter()
+        .map(|m| MemberEntry {
+            member: m.to_string(),
+            utility: m.utility.as_str().to_string(),
+            model: m.model.clone(),
+            effort: m.effort.map(|e| e.as_str().to_string()),
+            transport: m.utility.descriptor().transport.to_string(),
+        })
+        .collect();
+
+    let receipt = ReviewReceipt {
+        schema: 1,
+        run_id: run_id.clone(),
+        input: input.clone(),
+        manifest: ManifestSection {
+            profile: council.name.clone(),
+            options: OptionsSection {
+                quorum,
+                deadline_secs,
+                request_timeout_secs,
+                max_concurrency,
+                budget_usd,
+                max_requests,
+                options_hash: options_hash.clone(),
+            },
+            members: member_entries,
+        },
+        phases: PhasesSection {
+            review: phase1.participants.clone(),
+            voting: phase3.as_ref().map(|p| p.participants.clone()).unwrap_or_default(),
+            adjudication: phase4.as_ref().map(|p| p.judge.clone()),
+        },
+        findings,
+        warnings: warnings.clone(),
+        budget_usd,
+        budget_note: budget_usd
+            .map(|_| "advisory only — transports expose no cost data; not enforced".to_string()),
+        deadline_secs,
+        request_timeout_secs,
+        requests: RequestsSection { used: request_count.load(Ordering::SeqCst), max: max_requests },
+        resumed,
+    };
+
+    if let Some(manifest) = &args.manifest {
+        let json = serde_json::to_string_pretty(&receipt)?;
+        write_atomic(manifest, &json)
+            .with_context(|| format!("failed to write manifest {}", manifest.display()))?;
+    }
+
+    let rendered = match args.format.as_str() {
+        "json" => serde_json::to_string_pretty(&receipt)?,
+        _ => render_markdown(&receipt),
+    };
+    match &args.output {
+        Some(path) => {
+            std::fs::write(path, rendered)
+                .with_context(|| format!("failed to write receipt {}", path.display()))?;
+            eprintln!("{} Receipt written to {}", "✓".green(), path.display());
+        }
+        None => println!("{rendered}"),
+    }
+
+    for warning in &warnings {
+        eprintln!("  {} {}", "⚠".yellow(), warning);
+    }
+    Ok(())
+}
+
+// Resolve config for tests without touching the filesystem.
+#[allow(dead_code)]
+fn default_council() -> Council {
+    Config::default().resolve_profile(Some("deep")).expect("deep is a built-in profile")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use caucus_core::provider::{FanoutFailure, FanoutSuccess};
+    use caucus_core::{ErrorKind, MockProvider};
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: ReviewArgs,
+    }
+
+    fn parse(args: &[&str]) -> std::result::Result<TestCli, clap::Error> {
+        TestCli::try_parse_from(args)
+    }
+
+    // -- CLI conflicts and input selection ----------------------------------
+
+    #[test]
+    fn stdin_is_the_default_input() {
+        let cli = parse(&["test"]).unwrap();
+        assert!(cli.args.file.is_none());
+        assert!(!cli.args.git_diff);
+        assert!(!cli.args.staged);
+        assert_eq!(cli.args.format, "markdown");
+    }
+
+    #[test]
+    fn file_conflicts_with_git_inputs() {
+        assert!(parse(&["test", "--file", "a.rs", "--git-diff"]).is_err());
+        assert!(parse(&["test", "--file", "a.rs", "--staged"]).is_err());
+    }
+
+    #[test]
+    fn git_diff_conflicts_with_staged() {
+        assert!(parse(&["test", "--git-diff", "--staged"]).is_err());
+    }
+
+    #[test]
+    fn profile_conflicts_with_auto() {
+        assert!(parse(&["test", "--profile", "deep", "--auto"]).is_err());
+    }
+
+    #[test]
+    fn format_is_validated() {
+        assert!(parse(&["test", "--format", "yaml"]).is_err());
+        assert!(parse(&["test", "--format", "json"]).is_ok());
+    }
+
+    #[test]
+    fn budget_and_limits_parse() {
+        let cli = parse(&[
+            "test",
+            "--quorum",
+            "2",
+            "--deadline-secs",
+            "30",
+            "--max-concurrency",
+            "2",
+            "--budget-usd",
+            "1.5",
+            "--max-requests",
+            "7",
+        ])
+        .unwrap();
+        assert_eq!(cli.args.quorum, Some(2));
+        assert_eq!(cli.args.deadline_secs, Some(30));
+        assert_eq!(cli.args.max_concurrency, Some(2));
+        assert_eq!(cli.args.budget_usd, Some(1.5));
+        assert_eq!(cli.args.max_requests, Some(7));
+    }
+
+    // -- FNV64 determinism ---------------------------------------------------
+
+    #[test]
+    fn fnv64_matches_reference_vectors() {
+        // FNV-1a 64 offset basis for empty input.
+        assert_eq!(fnv64(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv64_hex(b""), "cbf29ce484222325");
+        assert_eq!(fnv64_hex(b"a"), "af63dc4c8601ec8c");
+        // Determinism: same input, same hash, every time.
+        assert_eq!(fnv64(b"review me"), fnv64(b"review me"));
+        assert_ne!(fnv64(b"review me"), fnv64(b"review me!"));
+    }
+
+    #[test]
+    fn anon_source_ids_are_deterministic_and_anonymous() {
+        let a = anon_source_id("claude:opus@xhigh");
+        assert_eq!(a, anon_source_id("claude:opus@xhigh"));
+        assert_ne!(a, anon_source_id("codex:default@xhigh"));
+        assert!(a.starts_with("src-"));
+        assert!(!a.contains("claude"), "source id must not leak the member: {a}");
+    }
+
+    // -- git argv construction ------------------------------------------------
+
+    #[test]
+    fn git_argv_is_explicit_and_shell_free() {
+        assert_eq!(git_diff_argv(false), vec!["git", "diff"]);
+        assert_eq!(git_diff_argv(true), vec!["git", "diff", "--staged"]);
+    }
+
+    #[test]
+    fn truncated_git_diff_is_rejected_instead_of_reviewed_as_complete() {
+        let output = ProcessOutput {
+            stdout: "partial diff".to_string(),
+            stderr: String::new(),
+            exit_code: Some(0),
+            latency_ms: 1,
+            truncated: true,
+        };
+        let error = complete_git_diff(output, "git diff").unwrap_err().to_string();
+        assert!(error.contains("incomplete diff"), "got: {error}");
+    }
+
+    // -- strict / fenced parsing ----------------------------------------------
+
+    const FINDING_JSON: &str = r#"{"findings": [{"title": "SQL injection", "severity": "critical", "evidence": "query built with format!", "file": "src/db.rs", "line": 42, "recommendation": "use params"}]}"#;
+
+    #[test]
+    fn parses_strict_findings_document() {
+        let findings = parse_findings(FINDING_JSON).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Critical);
+        assert_eq!(findings[0].line, Some(42));
+    }
+
+    #[test]
+    fn parses_fenced_findings_and_bare_arrays() {
+        let fenced =
+            format!("Here are my findings:\n```json\n{FINDING_JSON}\n```\nHope this helps!");
+        let findings = parse_findings(&fenced).unwrap();
+        assert_eq!(findings.len(), 1);
+
+        let bare = r#"[{"title": "t", "severity": "low", "evidence": "e", "file": null, "line": null, "recommendation": null}]"#;
+        let findings = parse_findings(bare).unwrap();
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn prose_is_never_accepted_as_findings() {
+        assert!(parse_findings("I found a bug on line 42, trust me.").is_err());
+        assert!(parse_findings("").is_err());
+        // Invalid severity is a schema error, not a finding.
+        let bad = r#"{"findings": [{"title": "t", "severity": "catastrophic", "evidence": "e"}]}"#;
+        assert!(parse_findings(bad).is_err());
+        // Unknown fields violate the strict schema.
+        let extra = r#"{"findings": [{"title": "t", "severity": "low", "evidence": "e", "confidence": 0.9}]}"#;
+        assert!(parse_findings(extra).is_err());
+    }
+
+    #[test]
+    fn parses_votes_strictly() {
+        let votes = parse_votes(
+            "```json\n{\"votes\": [{\"finding_id\": \"F1\", \"vote\": \"support\", \"reason\": \"evidence checks out\"}]}\n```",
+        )
+        .unwrap();
+        assert_eq!(votes.len(), 1);
+        assert_eq!(votes[0].vote, Vote::Support);
+        assert!(parse_votes("I support F1.").is_err());
+        let bad = r#"{"votes": [{"finding_id": "F1", "vote": "maybe"}]}"#;
+        assert!(parse_votes(bad).is_err());
+    }
+
+    #[test]
+    fn parses_adjudications_strictly() {
+        let doc = r#"{"adjudications": [{"finding_id": "F1", "accepted": true, "reason": "supported by votes", "evidence": "line 42"}]}"#;
+        let parsed = parse_adjudications(doc).unwrap();
+        assert!(parsed[0].accepted);
+        assert!(parse_adjudications("F1 is accepted.").is_err());
+    }
+
+    #[test]
+    fn adjudications_must_cover_known_findings_exactly_once() {
+        let finding = |id: &str| AttributedFinding {
+            id: id.to_string(),
+            source: "src-test".to_string(),
+            member: "model".to_string(),
+            finding: RawFinding {
+                title: "title".to_string(),
+                severity: Severity::High,
+                evidence: "evidence".to_string(),
+                file: None,
+                line: None,
+                recommendation: None,
+            },
+        };
+        let decision = |id: &str| Adjudication {
+            finding_id: id.to_string(),
+            accepted: true,
+            reason: "reason".to_string(),
+            evidence: None,
+        };
+        let findings = vec![finding("F1"), finding("F2")];
+        assert!(validate_adjudications(&[decision("F1"), decision("F2")], &findings).is_ok());
+        assert!(validate_adjudications(&[decision("F1")], &findings).unwrap_err().contains("F2"));
+        assert!(
+            validate_adjudications(&[decision("F1"), decision("F1")], &findings)
+                .unwrap_err()
+                .contains("duplicate")
+        );
+        assert!(
+            validate_adjudications(&[decision("F1"), decision("F3")], &findings)
+                .unwrap_err()
+                .contains("unknown")
+        );
+    }
+
+    // -- vote classification ---------------------------------------------------
+
+    #[test]
+    fn classification_from_raw_votes() {
+        assert_eq!(classify(3, 3), Classification::Unanimous);
+        assert_eq!(classify(2, 3), Classification::Majority);
+        assert_eq!(classify(1, 1), Classification::Unanimous);
+        assert_eq!(classify(1, 2), Classification::Disputed);
+        // No valid ballots: never fabricated as support.
+        assert_eq!(classify(0, 0), Classification::Disputed);
+        // Abstain-only is not unanimity.
+        assert_eq!(classify(0, 2), Classification::Disputed);
+    }
+
+    #[test]
+    fn classification_counts_every_valid_ballot() {
+        // Regression: unanimous requires every valid ballot to support — one
+        // support with the other ballots omitted or abstaining is not
+        // unanimous.
+        assert_eq!(classify(1, 3), Classification::Disputed);
+        assert_ne!(classify(2, 3), Classification::Unanimous);
+        assert_eq!(classify(3, 3), Classification::Unanimous);
+        // Regression: majority requires support from more than half of all
+        // valid ballots — one support plus two abstentions is not a majority,
+        // and exactly half is not more than half.
+        assert_eq!(classify(1, 3), Classification::Disputed);
+        assert_eq!(classify(2, 4), Classification::Disputed);
+        assert_eq!(classify(3, 4), Classification::Majority);
+        assert_eq!(classify(2, 3), Classification::Majority);
+        // Anything short of that is disputed.
+        assert_eq!(classify(0, 3), Classification::Disputed);
+    }
+
+    // -- partial failure and quorum --------------------------------------------
+
+    fn report(ok: usize, failed: usize, quorum: usize) -> FanoutReport {
+        FanoutReport {
+            successes: (0..ok)
+                .map(|i| FanoutSuccess {
+                    model: format!("m{i}"),
+                    transport: Transport::Command,
+                    content: "{}".into(),
+                    latency_ms: 10,
+                })
+                .collect(),
+            failures: (0..failed)
+                .map(|i| FanoutFailure {
+                    model: format!("bad{i}"),
+                    transport: Transport::Api,
+                    kind: ErrorKind::Timeout,
+                    message: "boom".into(),
+                    latency_ms: 5,
+                })
+                .collect(),
+            quorum,
+        }
+    }
+
+    #[test]
+    fn quorum_is_enforced_per_phase() {
+        assert!(enforce_quorum("review", 2, 2).is_ok());
+        let err = enforce_quorum("review", 1, 2).unwrap_err();
+        assert!(err.to_string().contains("quorum not met in review phase"));
+    }
+
+    #[test]
+    fn review_quorum_counts_only_semantically_valid_responses() {
+        // Regression: N unparseable responses must not satisfy quorum even
+        // though every transport request succeeded.
+        let mut r = report(2, 0, 2);
+        r.successes[0].content = "I found bugs, trust me.".into();
+        r.successes[1].content = "not json either".into();
+        let (findings, valid, invalid, warnings) = collect_findings(&r);
+        assert_eq!(valid, 0);
+        assert_eq!(invalid.len(), 2);
+        assert!(findings.is_empty());
+        assert_eq!(warnings.len(), 2);
+        assert!(enforce_quorum("review", valid, r.quorum).is_err());
+        // Receipt errors are phase-correct: findings, not votes.
+        assert!(invalid[0].error.contains("findings JSON"));
+        assert_eq!(invalid[0].status, "parse-error");
+
+        // A valid findings document with zero findings counts as a valid
+        // review response.
+        r.successes[0].content = "{\"findings\": []}".into();
+        let (_, valid, invalid, _) = collect_findings(&r);
+        assert_eq!(valid, 1);
+        assert_eq!(invalid.len(), 1);
+        assert!(enforce_quorum("review", valid, 1).is_ok());
+    }
+
+    #[test]
+    fn incomplete_ballots_are_discarded_and_never_satisfy_quorum() {
+        // Regression: ballots that miss findings, duplicate a vote, or vote
+        // only on unknown IDs are not schema-complete and must not count.
+        let known: std::collections::HashSet<&str> = ["F1", "F2"].into_iter().collect();
+        let mut r = report(5, 0, 5);
+        // Complete ballot: exactly one vote per known finding.
+        r.successes[0].content =
+            r#"{"votes": [{"finding_id": "F1", "vote": "support"}, {"finding_id": "F2", "vote": "abstain"}]}"#
+                .into();
+        // Missing a finding.
+        r.successes[1].content = r#"{"votes": [{"finding_id": "F1", "vote": "support"}]}"#.into();
+        // Duplicate vote for one finding.
+        r.successes[2].content =
+            r#"{"votes": [{"finding_id": "F1", "vote": "support"}, {"finding_id": "F1", "vote": "oppose"}, {"finding_id": "F2", "vote": "support"}]}"#
+                .into();
+        // Only unknown finding IDs.
+        r.successes[3].content = r#"{"votes": [{"finding_id": "F9", "vote": "support"}]}"#.into();
+        // Unparseable ballot.
+        r.successes[4].content = "I support F1 and F2.".into();
+
+        let (ballots, invalid, warnings) = collect_ballots(&r, &known);
+        assert_eq!(ballots.len(), 1, "only the complete ballot counts");
+        assert_eq!(ballots[0].votes.len(), 2);
+        assert_eq!(invalid.len(), 4);
+        assert!(enforce_quorum("voting", ballots.len(), 2).is_err());
+        assert!(enforce_quorum("voting", ballots.len(), 1).is_ok());
+
+        // Statuses and warnings are actionable and phase-correct.
+        assert_eq!(invalid[0].status, "incomplete-ballot");
+        assert!(invalid[0].error.contains("missing vote(s) for F2"));
+        assert_eq!(invalid[1].status, "incomplete-ballot");
+        assert!(invalid[1].error.contains("duplicate vote for `F1`"));
+        assert_eq!(invalid[2].status, "incomplete-ballot");
+        assert!(invalid[2].error.contains("unknown finding `F9`"));
+        assert_eq!(invalid[3].status, "parse-error");
+        assert!(invalid[3].error.contains("votes JSON"));
+        assert!(warnings.iter().any(|w| w.contains("incomplete ballot")));
+        assert!(!warnings.iter().any(|w| w.contains("findings JSON")));
+
+        // Receipts carry the phase-correct status per participant.
+        let records = participant_records(&r, &invalid);
+        assert_eq!(records[0].status, "ok");
+        assert_eq!(records[1].status, "incomplete-ballot");
+        assert!(records[1].error.as_ref().unwrap().contains("missing vote(s) for F2"));
+        assert_eq!(records[4].status, "parse-error");
+        assert!(records[4].error.as_ref().unwrap().contains("votes JSON"));
+    }
+
+    #[test]
+    fn participant_records_cover_success_parse_error_and_failure() {
+        let mut r = report(2, 1, 1);
+        r.successes[1].model = "m1".into();
+        let invalid = vec![InvalidResponse {
+            model: "m1".to_string(),
+            status: "parse-error",
+            error: "response was not valid votes JSON: nope".to_string(),
+        }];
+        let records = participant_records(&r, &invalid);
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].status, "ok");
+        assert!(records[0].error.is_none());
+        assert_eq!(records[1].status, "parse-error");
+        assert_eq!(records[1].error.as_deref(), Some("response was not valid votes JSON: nope"));
+        assert_eq!(records[2].status, "failed");
+        assert!(records[2].error.as_ref().unwrap().contains("timeout"));
+    }
+
+    // -- request budget ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn max_requests_is_a_hard_cap() {
+        let used = Arc::new(AtomicUsize::new(0));
+        let provider = BudgetedProvider {
+            inner: Arc::new(MockProvider::fixed("ok")),
+            used: Arc::clone(&used),
+            max: Some(2),
+        };
+        provider.complete("a", None).await.unwrap();
+        provider.complete("b", None).await.unwrap();
+        let err = provider.complete("c", None).await.unwrap_err();
+        assert!(err.to_string().contains("--max-requests 2"));
+        // The rejected request does not consume budget.
+        assert_eq!(used.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn uncapped_budget_still_counts_everything() {
+        // Regression: the counter is the receipt's request total, so every
+        // admitted request increments it even with no cap configured.
+        let used = Arc::new(AtomicUsize::new(0));
+        let provider = BudgetedProvider {
+            inner: Arc::new(MockProvider::fixed("ok")),
+            used: Arc::clone(&used),
+            max: None,
+        };
+        for _ in 0..5 {
+            provider.complete("x", None).await.unwrap();
+        }
+        assert_eq!(used.load(Ordering::SeqCst), 5);
+    }
+
+    struct NeverProvider;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for NeverProvider {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+            std::future::pending().await
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn judge_request_timeout_is_enforced_without_a_run_deadline() {
+        let error = complete_with_timeout(
+            &NeverProvider,
+            "judge",
+            None,
+            Duration::from_secs(3),
+            "judge `slow`",
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(caucus_core::ProviderError::classify(&error), caucus_core::ErrorKind::Timeout);
+    }
+
+    #[tokio::test]
+    async fn designated_judge_always_consumes_request_budget() {
+        // Regression: a designated judge outside the council members is built
+        // dedicated and must still consume the hard request budget.
+        let member = |s: &str| s.parse().unwrap();
+        let config = Config::default();
+        let council = Council {
+            name: "t".to_string(),
+            description: None,
+            members: vec![member("ollama:llama3.2:latest")],
+            judge: Some(member("ollama:phi4")),
+            strategy: "judge".to_string(),
+            quorum: 1,
+            deadline_secs: None,
+            request_timeout_secs: None,
+            budget_usd: None,
+        };
+        let base = council::build_council_provider(&council, &config).unwrap();
+
+        // External designated judge: dedicated provider, budget-wrapped. With
+        // the budget fully consumed by council phases, the adjudication
+        // request fails honestly before any transport work is attempted.
+        let (name, judge) = council::select_judge(&council, &base, &config).unwrap();
+        assert!(matches!(judge, council::JudgeProvider::Owned(_)));
+        let used = Arc::new(AtomicUsize::new(1));
+        let judge = budgeted_judge(&base, &name, judge, Arc::clone(&used), Some(1));
+        let err = judge.complete("adjudicate", None).await.unwrap_err();
+        assert!(err.to_string().contains("--max-requests 1"));
+        assert_eq!(used.load(Ordering::SeqCst), 1, "rejected request does not consume budget");
+
+        // Member judge: borrowed from the base set and wrapped exactly once.
+        let council = Council { judge: Some(member("ollama:llama3.2:latest")), ..council };
+        let (name, judge) = council::select_judge(&council, &base, &config).unwrap();
+        assert!(matches!(judge, council::JudgeProvider::Borrowed(_)));
+        let used = Arc::new(AtomicUsize::new(0));
+        let judge = budgeted_judge(&base, &name, judge, Arc::clone(&used), Some(0));
+        let err = judge.complete("adjudicate", None).await.unwrap_err();
+        assert!(err.to_string().contains("--max-requests 0"));
+    }
+
+    // -- checkpoint compatibility and resume ------------------------------------
+
+    fn temp_checkpoint(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "caucus-review-test-{}-{}",
+            std::process::id(),
+            fnv64_hex(name.as_bytes())
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("checkpoint.json")
+    }
+
+    #[test]
+    fn checkpoint_roundtrips_and_validates_version() {
+        let path = temp_checkpoint("roundtrip");
+        let mut ckpt = Checkpoint::fresh("run1".into(), "in".into(), "opt".into());
+        ckpt.phase1 =
+            Some(Phase1State { participants: vec![], findings: vec![], warnings: vec![] });
+        save_checkpoint(&path, &ckpt).unwrap();
+
+        let loaded = load_checkpoint(&path).unwrap();
+        assert_eq!(loaded.run_id, "run1");
+        assert_eq!(loaded.input_hash, "in");
+        assert!(loaded.phase1.is_some());
+        assert!(loaded.phase3.is_none());
+
+        // Unsupported versions are rejected.
+        let mut raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        raw["version"] = serde_json::json!(99);
+        std::fs::write(&path, raw.to_string()).unwrap();
+        let err = load_checkpoint(&path).unwrap_err();
+        assert!(err.to_string().contains("version 99"));
+
+        // Missing checkpoint is an honest error.
+        let err = load_checkpoint(&path.with_file_name("nope.json")).unwrap_err();
+        assert!(err.to_string().contains("no checkpoint"));
+    }
+
+    #[test]
+    fn checkpoint_path_tracks_manifest() {
+        assert_eq!(
+            checkpoint_path(Some(Path::new("/tmp/m.json"))),
+            PathBuf::from("/tmp/m.json.checkpoint.json")
+        );
+        assert_eq!(checkpoint_path(None), PathBuf::from(".caucus-review.checkpoint.json"));
+    }
+
+    #[test]
+    fn checkpoint_writes_are_atomic_and_leave_no_temp_files() {
+        // Writes go to a sibling temp file renamed over the target, so an
+        // interruption can never leave a partially written resume file — and
+        // normal operation leaves no temp files behind.
+        let path = temp_checkpoint("atomic");
+        let ckpt = Checkpoint::fresh("run1".into(), "in".into(), "opt".into());
+        save_checkpoint(&path, &ckpt).unwrap();
+        // Rewriting over an existing checkpoint replaces it in place.
+        save_checkpoint(&path, &ckpt).unwrap();
+        let loaded = load_checkpoint(&path).unwrap();
+        assert_eq!(loaded.run_id, "run1");
+
+        let dir = path.parent().unwrap();
+        let leftovers: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "atomic writes left temp files: {leftovers:?}");
+    }
+
+    #[test]
+    fn resume_rejects_mismatched_hashes() {
+        // The exact comparison run() performs before reusing any phase.
+        let ckpt = Checkpoint::fresh("run1".into(), "hash-a".into(), "opts-a".into());
+        let matches =
+            |input: &str, opts: &str| ckpt.input_hash == input && ckpt.options_hash == opts;
+        assert!(matches("hash-a", "opts-a"));
+        assert!(!matches("hash-b", "opts-a"));
+        assert!(!matches("hash-a", "opts-b"));
+    }
+
+    #[test]
+    fn checkpoint_requests_used_defaults_to_zero_and_roundtrips() {
+        // Backward compatibility: checkpoints written before the field existed
+        // still load, seeded at zero.
+        let legacy = r#"{"version":1,"run_id":"r","input_hash":"i","options_hash":"o"}"#;
+        let loaded: Checkpoint = serde_json::from_str(legacy).unwrap();
+        assert_eq!(loaded.requests_used, 0);
+        assert_eq!(Checkpoint::fresh("r".into(), "i".into(), "o".into()).requests_used, 0);
+
+        // The cumulative total survives a save/load roundtrip.
+        let path = temp_checkpoint("requests-used");
+        let mut ckpt = Checkpoint::fresh("r".into(), "i".into(), "o".into());
+        ckpt.requests_used = 7;
+        save_checkpoint(&path, &ckpt).unwrap();
+        assert_eq!(load_checkpoint(&path).unwrap().requests_used, 7);
+    }
+
+    #[tokio::test]
+    async fn completed_resume_reuses_phases_and_reports_cumulative_total() {
+        // Regression: an uncapped 3-member review makes 7 requests (3 review +
+        // 3 vote + 1 judge). A resume of the completed run reuses every phase,
+        // so the counter seeded from the checkpoint is the receipt's total.
+        let used = Arc::new(AtomicUsize::new(0));
+        let provider = BudgetedProvider {
+            inner: Arc::new(MockProvider::fixed("ok")),
+            used: Arc::clone(&used),
+            max: None,
+        };
+        for _ in 0..7 {
+            provider.complete("x", None).await.unwrap();
+        }
+        let mut ckpt = Checkpoint::fresh("r".into(), "i".into(), "o".into());
+        ckpt.requests_used = used.load(Ordering::SeqCst);
+        assert_eq!(ckpt.requests_used, 7);
+
+        // Resume: run() seeds the counter from the checkpoint; with all phases
+        // reused no new requests are admitted, so the total stays cumulative.
+        let resumed = AtomicUsize::new(ckpt.requests_used);
+        assert_eq!(resumed.load(Ordering::SeqCst), 7);
+    }
+
+    #[tokio::test]
+    async fn capped_resume_seeds_counter_and_judge_stays_denied() {
+        // Regression: with --max-requests 6 a 3-member run exhausts the budget
+        // in the voting phase (3 review + 3 vote) and checkpoints
+        // requests_used = 6. On resume the counter starts at 6, so the judge
+        // remains denied and the denied request is not counted.
+        let ckpt = {
+            let mut c = Checkpoint::fresh("r".into(), "i".into(), "o".into());
+            c.requests_used = 6;
+            c
+        };
+        let used = Arc::new(AtomicUsize::new(ckpt.requests_used));
+        let judge = BudgetedProvider {
+            inner: Arc::new(MockProvider::fixed("ok")),
+            used: Arc::clone(&used),
+            max: Some(6),
+        };
+        let err = judge.complete("adjudicate", None).await.unwrap_err();
+        assert!(err.to_string().contains("--max-requests 6"));
+        assert_eq!(used.load(Ordering::SeqCst), 6, "denied request is not counted");
+    }
+
+    // -- receipt rendering -------------------------------------------------------
+
+    fn sample_receipt() -> ReviewReceipt {
+        ReviewReceipt {
+            schema: 1,
+            run_id: "abc123".into(),
+            input: InputMeta {
+                source: "file".into(),
+                detail: "src/main.rs".into(),
+                bytes: 128,
+                hash: "deadbeef".into(),
+            },
+            manifest: ManifestSection {
+                profile: "deep".into(),
+                options: OptionsSection {
+                    quorum: 3,
+                    deadline_secs: Some(600),
+                    request_timeout_secs: Some(240),
+                    max_concurrency: 4,
+                    budget_usd: Some(1.0),
+                    max_requests: Some(20),
+                    options_hash: "optshash".into(),
+                },
+                members: vec![MemberEntry {
+                    member: "kimi:kimi-code/k3@high".into(),
+                    utility: "kimi".into(),
+                    model: "kimi-code/k3".into(),
+                    effort: Some("high".into()),
+                    transport: "command".into(),
+                }],
+            },
+            phases: PhasesSection {
+                review: vec![ParticipantRecord {
+                    member: "kimi:kimi-code/k3@high".into(),
+                    transport: "command".into(),
+                    status: "ok".into(),
+                    latency_ms: 120,
+                    error: None,
+                }],
+                voting: vec![],
+                adjudication: None,
+            },
+            findings: vec![ReceiptFinding {
+                id: "F1".into(),
+                title: "Unchecked unwrap".into(),
+                severity: Severity::High,
+                file: Some("src/main.rs".into()),
+                line: Some(10),
+                evidence: "value.unwrap()".into(),
+                recommendation: Some("handle the error".into()),
+                source: "src-01234567".into(),
+                member: "kimi:kimi-code/k3@high".into(),
+                votes: vec![
+                    ReceiptVote {
+                        voter: "claude:opus@xhigh".into(),
+                        vote: Vote::Support,
+                        reason: Some("evidence is exact".into()),
+                    },
+                    ReceiptVote {
+                        voter: "codex:default@xhigh".into(),
+                        vote: Vote::Oppose,
+                        reason: Some("infallible here".into()),
+                    },
+                ],
+                dissent: vec![ReceiptVote {
+                    voter: "codex:default@xhigh".into(),
+                    vote: Vote::Oppose,
+                    reason: Some("infallible here".into()),
+                }],
+                adjudication: Some(Adjudication {
+                    finding_id: "F1".into(),
+                    accepted: true,
+                    reason: "majority support with cited evidence".into(),
+                    evidence: Some("value.unwrap()".into()),
+                }),
+                classification: Some(Classification::Disputed),
+            }],
+            warnings: vec!["budget_usd is advisory".into()],
+            budget_usd: Some(1.0),
+            budget_note: Some("advisory only".into()),
+            deadline_secs: Some(600),
+            request_timeout_secs: Some(240),
+            requests: RequestsSection { used: 11, max: Some(20) },
+            resumed: false,
+        }
+    }
+
+    #[test]
+    fn markdown_receipt_is_provenance_rich() {
+        let md = render_markdown(&sample_receipt());
+        for needle in [
+            "abc123",
+            "deadbeef",
+            "src/main.rs:10",
+            "kimi:kimi-code/k3@high",
+            "disputed",
+            "majority support with cited evidence",
+            "infallible here",
+            "budget_usd is advisory",
+            "11/20 used",
+        ] {
+            assert!(md.contains(needle), "markdown receipt missing `{needle}`:\n{md}");
+        }
+    }
+
+    #[test]
+    fn json_receipt_serializes_all_sections() {
+        let json = serde_json::to_string_pretty(&sample_receipt()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["run_id"], "abc123");
+        assert_eq!(value["input"]["hash"], "deadbeef");
+        assert_eq!(value["manifest"]["options"]["quorum"], 3);
+        assert_eq!(value["manifest"]["members"][0]["effort"], "high");
+        assert_eq!(value["phases"]["review"][0]["latency_ms"], 120);
+        assert_eq!(value["findings"][0]["classification"], "disputed");
+        assert_eq!(value["findings"][0]["votes"][1]["vote"], "oppose");
+        assert_eq!(value["findings"][0]["adjudication"]["accepted"], true);
+        assert_eq!(value["requests"]["used"], 11);
+        assert_eq!(value["warnings"][0], "budget_usd is advisory");
+    }
+
+    // -- deep profile sanity ------------------------------------------------------
+
+    #[test]
+    fn deep_profile_has_exact_members() {
+        let council = default_council();
+        let members: Vec<String> = council.members.iter().map(|m| m.to_string()).collect();
+        assert_eq!(
+            members,
+            vec![
+                "claude:opus@xhigh",
+                "claude:claude-fable-5@xhigh",
+                "codex:default@xhigh",
+                "opencode:zai-coding-plan/glm-5.2@xhigh",
+                "kimi:kimi-code/k3@high",
+            ]
+        );
+    }
+}

--- a/crates/caucus-cli/src/commands/run.rs
+++ b/crates/caucus-cli/src/commands/run.rs
@@ -1,0 +1,67 @@
+//! Shared whole-run wall-clock deadline.
+
+use std::future::Future;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::time::Instant;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RunDeadline {
+    started: Instant,
+    limit: Option<Duration>,
+}
+
+impl RunDeadline {
+    pub fn new(seconds: Option<u64>) -> Self {
+        Self { started: Instant::now(), limit: seconds.map(Duration::from_secs) }
+    }
+
+    /// Clamp a request/process timeout to the time remaining in the run.
+    pub fn turn_timeout(&self, requested: Duration) -> Result<Duration> {
+        match self.remaining()? {
+            Some(remaining) => Ok(requested.min(remaining)),
+            None => Ok(requested),
+        }
+    }
+
+    /// Run a phase within the remaining whole-run wall-clock budget.
+    pub async fn wait<F: Future>(&self, future: F) -> Result<F::Output> {
+        match self.remaining()? {
+            Some(remaining) => tokio::time::timeout(remaining, future)
+                .await
+                .map_err(|_| anyhow::anyhow!("whole-run deadline exceeded")),
+            None => Ok(future.await),
+        }
+    }
+
+    fn remaining(&self) -> Result<Option<Duration>> {
+        let Some(limit) = self.limit else { return Ok(None) };
+        let remaining = limit
+            .checked_sub(self.started.elapsed())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| anyhow::anyhow!("whole-run deadline exceeded"))?;
+        Ok(Some(remaining))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn deadline_bounds_the_whole_run_and_each_turn() {
+        let deadline = RunDeadline::new(Some(10));
+        let initial = deadline.turn_timeout(Duration::from_secs(30)).unwrap();
+        assert!(initial <= Duration::from_secs(10) && initial > Duration::from_secs(9));
+        tokio::time::advance(Duration::from_secs(4)).await;
+        let remaining = deadline.turn_timeout(Duration::from_secs(30)).unwrap();
+        assert!(remaining <= Duration::from_secs(6) && remaining > Duration::from_secs(5));
+        let result = deadline
+            .wait(async {
+                tokio::time::sleep(Duration::from_secs(7)).await;
+            })
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/caucus-cli/src/commands/serve.rs
+++ b/crates/caucus-cli/src/commands/serve.rs
@@ -10,9 +10,11 @@ use clap::Args;
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 
-use caucus_core::{Candidate, ConsensusResult, OutputFormat, consensus};
+use caucus_core::{
+    Candidate, ConsensusResult, LlmProvider, MultiProvider, OutputFormat, Transport, consensus,
+};
 
-use super::build_single_provider;
+use super::{build_single_provider, default_models};
 
 #[derive(Args)]
 pub struct ServeArgs {
@@ -43,9 +45,7 @@ pub async fn run(args: ServeArgs) -> anyhow::Result<()> {
         .route("/health", get(health))
         .route("/v1/consensus", post(consensus_endpoint))
         .route("/v1/pipeline", post(pipeline_endpoint))
-        .with_state(state)
-        // Permissive CORS is intentional — this is a local dev tool, not a production API
-        .layer(tower_http::cors::CorsLayer::permissive());
+        .with_state(state);
 
     let addr = format!("{}:{}", args.host, args.port);
     eprintln!("{} caucus API server listening on {}", "▶".green(), addr.cyan(),);
@@ -70,6 +70,9 @@ struct ConsensusRequest {
     strategy: String,
     #[serde(default = "default_format")]
     format: String,
+    /// Explicit HTTP/API model to use for strategies that need an LLM judge.
+    #[serde(default)]
+    judge_model: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -143,15 +146,21 @@ async fn consensus_endpoint(
         .parse()
         .map_err(|e: anyhow::Error| (StatusCode::BAD_REQUEST, format!("Invalid format: {e}")))?;
 
-    // Build judge LLM if needed
-    let judge_llm: Option<Box<dyn caucus_core::LlmProvider>> = if strategy_needs_llm(&req.strategy)
-    {
-        // Try to use the first candidate's model, or fall back to env-configured default
-        let model_name = candidates
-            .first()
-            .and_then(|c| c.model.clone())
-            .unwrap_or_else(|| "gpt-4o".to_string());
-        build_single_provider(&model_name).ok()
+    let judge_llm: Option<Box<dyn LlmProvider>> = if strategy_needs_llm(&req.strategy) {
+        let model_name = req
+            .judge_model
+            .clone()
+            .or_else(|| candidates.first().and_then(|candidate| candidate.model.clone()))
+            .or_else(|| default_models().into_iter().next())
+            .ok_or_else(|| {
+                (StatusCode::BAD_REQUEST, "judge strategy requires judge_model".to_string())
+            })?;
+        Some(build_server_provider(&model_name).map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Judge provider is not available to HTTP serve: {error}"),
+            )
+        })?)
     } else {
         None
     };
@@ -214,19 +223,43 @@ async fn pipeline_endpoint(
         };
     }
 
-    let provider = super::build_provider(&req.models)
+    let provider = build_server_multi_provider(&req.models)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("Provider error: {e}")))?;
 
-    // Use first model as judge
-    let judge_llm: Option<Box<dyn caucus_core::LlmProvider>> =
-        req.models.first().and_then(|m| build_single_provider(m).ok());
+    let judge_llm = req.models.first().and_then(|model| provider.get(model));
 
     let result = pipeline
-        .run(&req.prompt, &provider, judge_llm.as_deref())
+        .run(&req.prompt, &provider, judge_llm)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Pipeline error: {e}")))?;
 
     Ok(Json(ConsensusResponse::from((result, &format))))
+}
+
+/// The unauthenticated HTTP surface must never gain access to installed
+/// subscription utilities. This explicit transport boundary keeps that true
+/// even if the general provider parser later learns more command aliases.
+fn build_server_provider(model: &str) -> anyhow::Result<Box<dyn LlmProvider>> {
+    if model.starts_with("cli:") || model.starts_with("acp:") {
+        anyhow::bail!("command and ACP provider specs are disabled on unauthenticated HTTP serve");
+    }
+
+    let provider = build_single_provider(model)?;
+    match provider.transport() {
+        Transport::Api | Transport::LocalServer => Ok(provider),
+        Transport::Command | Transport::Acp => anyhow::bail!(
+            "transport '{}' is disabled on unauthenticated HTTP serve",
+            provider.transport()
+        ),
+    }
+}
+
+fn build_server_multi_provider(models: &[String]) -> anyhow::Result<MultiProvider> {
+    let mut provider = MultiProvider::new();
+    for model in models {
+        provider = provider.add_shared(model.clone(), Arc::from(build_server_provider(model)?));
+    }
+    Ok(provider)
 }
 
 fn strategy_needs_llm(name: &str) -> bool {
@@ -310,7 +343,7 @@ async fn run_mcp() -> anyhow::Result<()> {
                                         },
                                         "strategy": {
                                             "type": "string",
-                                            "enum": ["majority_vote", "weighted_vote", "judge", "debate"],
+                                            "enum": ["majority_vote", "weighted_vote"],
                                             "default": "majority_vote"
                                         }
                                     },
@@ -394,4 +427,26 @@ async fn run_mcp() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_serve_rejects_command_and_acp_provider_specs() {
+        for model in ["cli:claude", "cli:codex", "acp:kimi"] {
+            let error = match build_server_provider(model) {
+                Ok(_) => panic!("{model} must not cross the unauthenticated HTTP boundary"),
+                Err(error) => error.to_string(),
+            };
+            assert!(error.contains("disabled on unauthenticated HTTP serve"));
+        }
+    }
+
+    #[test]
+    fn http_serve_allows_non_command_providers() {
+        let provider = build_server_provider("mock").unwrap();
+        assert_eq!(provider.transport(), Transport::Api);
+    }
 }

--- a/crates/caucus-cli/src/main.rs
+++ b/crates/caucus-cli/src/main.rs
@@ -7,7 +7,8 @@ use clap::{Parser, Subcommand};
 /// Check if we need to inject "ask" as the default subcommand.
 /// Returns true when the first positional arg is not a known subcommand.
 fn needs_subcommand_injection(args: &[String]) -> bool {
-    let subcommands = ["ask", "compare", "debate", "bench", "serve", "help"];
+    let subcommands =
+        ["ask", "compare", "debate", "bench", "serve", "doctor", "profiles", "review", "help"];
 
     // Find the first positional argument by skipping global flags
     let mut i = 1;
@@ -58,6 +59,12 @@ enum Commands {
     Bench(commands::bench::BenchArgs),
     /// Start an HTTP API or MCP server
     Serve(commands::serve::ServeArgs),
+    /// Check adapter readiness, config validity, and profile health
+    Doctor(commands::doctor::DoctorArgs),
+    /// List or show council profiles (built-ins and user-defined)
+    Profiles(commands::profiles::ProfilesArgs),
+    /// Adjudicated multi-model code/text review
+    Review(commands::review::ReviewArgs),
 }
 
 #[tokio::main]
@@ -89,5 +96,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::Debate(args) => commands::debate::run(args).await,
         Commands::Bench(args) => commands::bench::run(args).await,
         Commands::Serve(args) => commands::serve::run(args).await,
+        Commands::Doctor(args) => commands::doctor::run(args).await,
+        Commands::Profiles(args) => commands::profiles::run(args).await,
+        Commands::Review(args) => commands::review::run(args).await,
     }
 }

--- a/crates/caucus-core/Cargo.toml
+++ b/crates/caucus-core/Cargo.toml
@@ -12,7 +12,12 @@ serde_json.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+toml = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+futures = "0.3"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/caucus-core/src/adapters.rs
+++ b/crates/caucus-core/src/adapters.rs
@@ -1,0 +1,1282 @@
+//! Provider adapters: registry, member specs, discovery, and factories.
+//!
+//! Each adapter knows how to reach one kind of model host:
+//!
+//! - **CLI adapters** (Claude, Codex, Kimi, opencode, Grok) run the installed
+//!   binary through [`CommandProvider`] — explicit argv executed via
+//!   [`run_argv`], never a shell, and never touching the CLI's credential
+//!   store.
+//! - **Local servers** (Ollama, LM Studio) and the Gemini remote API are
+//!   backed by [`crate::provider::HttpProvider`].
+//! - **ACP** is a recognized transport with an honest unsupported status.
+//!
+//! Effort mappings are evidence-based and never silently dropped: an
+//! unsupported effort value is a hard error. Claude, Codex, and opencode
+//! take effort as exact argv; Kimi effort (low/high/max) is delivered
+//! through the documented `KIMI_MODEL_THINKING_EFFORT` environment
+//! override — a non-secret value applied to the child process only. The
+//! Kimi CLI (verified 0.27.0) has no `--config-file` flag and no effort
+//! argv flag; `KIMI_MODEL_THINKING_EFFORT` is the supported
+//! per-invocation mechanism and requires no credential access.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::process::{ProcessLimits, ProcessOutput, ProcessSpec, find_on_path, run_argv};
+use crate::provider::HttpProvider;
+pub use crate::types::Transport;
+use crate::types::{LlmProvider, ProviderOptions};
+
+/// Reasoning effort level requested from a model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Effort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+    Xhigh,
+    Max,
+}
+
+impl Effort {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Xhigh => "xhigh",
+            Self::Max => "max",
+        }
+    }
+}
+
+impl std::fmt::Display for Effort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for Effort {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "minimal" => Ok(Self::Minimal),
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "xhigh" => Ok(Self::Xhigh),
+            "max" => Ok(Self::Max),
+            other => anyhow::bail!(
+                "unknown effort `{other}` (expected one of: minimal, low, medium, high, xhigh, max)"
+            ),
+        }
+    }
+}
+
+/// A known provider utility (CLI tool, local server, remote API, or ACP).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Utility {
+    Claude,
+    Codex,
+    Kimi,
+    Opencode,
+    Ollama,
+    Lmstudio,
+    Gemini,
+    Grok,
+    Acp,
+}
+
+impl Utility {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Kimi => "kimi",
+            Self::Opencode => "opencode",
+            Self::Ollama => "ollama",
+            Self::Lmstudio => "lmstudio",
+            Self::Gemini => "gemini",
+            Self::Grok => "grok",
+            Self::Acp => "acp",
+        }
+    }
+
+    /// This utility's adapter descriptor.
+    pub fn descriptor(&self) -> &'static AdapterDescriptor {
+        descriptor(self.as_str()).expect("every utility has a descriptor")
+    }
+}
+
+impl std::fmt::Display for Utility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for Utility {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "claude" => Ok(Self::Claude),
+            "codex" => Ok(Self::Codex),
+            "kimi" => Ok(Self::Kimi),
+            "opencode" => Ok(Self::Opencode),
+            "ollama" => Ok(Self::Ollama),
+            "lmstudio" => Ok(Self::Lmstudio),
+            "gemini" => Ok(Self::Gemini),
+            "grok" => Ok(Self::Grok),
+            "acp" => Ok(Self::Acp),
+            "glm" => Ok(Self::Opencode), // legacy alias for the GLM-via-opencode provider
+            other => {
+                anyhow::bail!("unknown utility `{other}` (known: {})", utility_ids().join(", "))
+            }
+        }
+    }
+}
+
+/// One council member: `utility:model@effort`.
+///
+/// The model pin is *exact*: it is passed verbatim to the adapter, never
+/// aliased or normalized. The effort suffix is optional and validated
+/// against the utility's native effort support.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "MemberSpecWire", into = "MemberSpecWire")]
+pub struct MemberSpec {
+    pub utility: Utility,
+    pub model: String,
+    pub effort: Option<Effort>,
+}
+
+/// Serde wire form; validation happens in the `TryFrom` conversion.
+#[derive(Serialize, Deserialize)]
+struct MemberSpecWire {
+    utility: Utility,
+    model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    effort: Option<Effort>,
+}
+
+impl From<MemberSpec> for MemberSpecWire {
+    fn from(m: MemberSpec) -> Self {
+        Self { utility: m.utility, model: m.model, effort: m.effort }
+    }
+}
+
+impl TryFrom<MemberSpecWire> for MemberSpec {
+    type Error = anyhow::Error;
+
+    fn try_from(wire: MemberSpecWire) -> Result<Self> {
+        let member = Self { utility: wire.utility, model: wire.model, effort: wire.effort };
+        member.validate()?;
+        Ok(member)
+    }
+}
+
+impl MemberSpec {
+    /// Parse `utility:model@effort`. The utility is split at the first `:`;
+    /// the effort suffix is everything after the last `@`.
+    pub fn parse(spec: &str) -> Result<Self> {
+        let spec = spec.trim();
+        let (utility, rest) = spec.split_once(':').ok_or_else(|| {
+            anyhow::anyhow!("member spec `{spec}` must be `utility:model@effort` (missing `:`)")
+        })?;
+        let utility: Utility = utility.parse()?;
+        let (model, effort) = match rest.rsplit_once('@') {
+            Some((m, e)) if !e.is_empty() => (m, Some(e.parse()?)),
+            Some((m, _)) => (m, None), // trailing `@` with empty effort
+            None => (rest, None),
+        };
+        let member = Self { utility, model: model.to_string(), effort };
+        member.validate()?;
+        Ok(member)
+    }
+
+    /// Validate a non-empty exact model pin and native effort support.
+    pub fn validate(&self) -> Result<()> {
+        if self.model.trim().is_empty() {
+            anyhow::bail!("member spec for `{}` must pin an exact, non-empty model", self.utility);
+        }
+        if self.model.chars().any(char::is_whitespace) {
+            anyhow::bail!("member spec for `{}` has whitespace in the model pin", self.utility);
+        }
+        if let Some(effort) = self.effort {
+            validate_effort(self.utility.descriptor(), effort)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for MemberSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.utility, self.model)?;
+        if let Some(e) = &self.effort {
+            write!(f, "@{e}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for MemberSpec {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
+    }
+}
+
+/// Release stability advertised by an adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Stability {
+    /// First-class, tested adapter.
+    Stable,
+    /// Works, but the integration may change as the upstream CLI evolves.
+    Experimental,
+}
+
+impl std::fmt::Display for Stability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stable => f.write_str("stable"),
+            Self::Experimental => f.write_str("experimental"),
+        }
+    }
+}
+
+/// Static description of a provider adapter.
+#[derive(Debug, Clone)]
+pub struct AdapterDescriptor {
+    /// Short id used in member specs (`claude`, `codex`, `opencode`, ...).
+    pub id: &'static str,
+    pub display_name: &'static str,
+    pub transport: Transport,
+    pub stability: Stability,
+    /// Effort values this adapter accepts natively (empty = no effort support).
+    pub efforts: &'static [Effort],
+    /// Binary probed on `PATH` (command transports).
+    pub binary: Option<&'static str>,
+    /// Environment variable holding the API key (api transports).
+    pub api_key_env: Option<&'static str>,
+    /// Default base URL (local-server transports).
+    pub base_url: Option<&'static str>,
+    pub notes: &'static str,
+}
+
+impl AdapterDescriptor {
+    pub fn supports_effort(&self, effort: Effort) -> bool {
+        self.efforts.contains(&effort)
+    }
+}
+
+/// Backwards-compatible alias for [`AdapterDescriptor`].
+pub type ProviderDescriptor = AdapterDescriptor;
+
+use Effort::*;
+
+/// All known adapters, in display order.
+pub fn descriptors() -> &'static [AdapterDescriptor] {
+    &[
+        AdapterDescriptor {
+            id: "claude",
+            display_name: "Claude CLI",
+            transport: Transport::Command,
+            stability: Stability::Stable,
+            // `claude --help`: --effort <level>
+            efforts: &[Low, Medium, High, Xhigh, Max],
+            binary: Some("claude"),
+            api_key_env: None,
+            base_url: None,
+            notes: "Native effort via `--effort` argv flag",
+        },
+        AdapterDescriptor {
+            id: "codex",
+            display_name: "Codex CLI",
+            transport: Transport::Command,
+            stability: Stability::Stable,
+            // `codex debug models`: supported_reasoning_levels per model
+            efforts: &[Minimal, Low, Medium, High, Xhigh],
+            binary: Some("codex"),
+            api_key_env: None,
+            base_url: None,
+            notes: "Native effort via `-c model_reasoning_effort=...`",
+        },
+        AdapterDescriptor {
+            id: "kimi",
+            display_name: "Kimi CLI",
+            transport: Transport::Command,
+            stability: Stability::Experimental,
+            // Kimi CLI `[thinking]` config: support_efforts = ["low", "high", "max"]
+            efforts: &[Low, High, Max],
+            binary: Some("kimi"),
+            api_key_env: None,
+            base_url: None,
+            notes: "Effort via the KIMI_MODEL_THINKING_EFFORT env override (no argv flag exists)",
+        },
+        AdapterDescriptor {
+            id: "opencode",
+            display_name: "opencode / GLM",
+            transport: Transport::Command,
+            stability: Stability::Experimental,
+            // `opencode run --help`: --variant (e.g. minimal, high, max)
+            efforts: &[Minimal, Low, Medium, High, Xhigh, Max],
+            binary: Some("opencode"),
+            api_key_env: None,
+            base_url: None,
+            notes: "Native effort via `--variant` argv flag",
+        },
+        AdapterDescriptor {
+            id: "ollama",
+            display_name: "Ollama (local server)",
+            transport: Transport::LocalServer,
+            stability: Stability::Stable,
+            efforts: &[],
+            binary: None,
+            api_key_env: None,
+            base_url: Some("http://localhost:11434/v1"),
+            notes: "Local OpenAI-compatible server, no API key",
+        },
+        AdapterDescriptor {
+            id: "lmstudio",
+            display_name: "LM Studio (local server)",
+            transport: Transport::LocalServer,
+            stability: Stability::Stable,
+            efforts: &[],
+            binary: None,
+            api_key_env: None,
+            base_url: Some("http://localhost:1234/v1"),
+            notes: "Local OpenAI-compatible server, no API key",
+        },
+        AdapterDescriptor {
+            id: "gemini",
+            display_name: "Gemini API",
+            transport: Transport::Api,
+            stability: Stability::Experimental,
+            efforts: &[],
+            binary: None,
+            api_key_env: Some("GEMINI_API_KEY"),
+            base_url: None,
+            notes: "Remote API via HttpProvider; ready only when GEMINI_API_KEY is set",
+        },
+        AdapterDescriptor {
+            id: "grok",
+            display_name: "Grok Build CLI",
+            transport: Transport::Command,
+            stability: Stability::Experimental,
+            // `grok --help` (0.2.103): --reasoning-effort; the CLI rejects
+            // xhigh/max and reports the exact accepted set below.
+            efforts: &[Low, Medium, High],
+            binary: Some("grok"),
+            api_key_env: None,
+            base_url: None,
+            notes: "Subscription CLI; native effort via `--reasoning-effort` (low, medium, high)",
+        },
+        AdapterDescriptor {
+            id: "acp",
+            display_name: "Agent Client Protocol",
+            transport: Transport::Acp,
+            stability: Stability::Experimental,
+            efforts: &[],
+            binary: None,
+            api_key_env: None,
+            base_url: None,
+            notes: "Recognized but not supported by this build",
+        },
+    ]
+}
+
+/// Look up a descriptor by id.
+pub fn descriptor(id: &str) -> Option<&'static AdapterDescriptor> {
+    descriptors().iter().find(|d| d.id == id)
+}
+
+/// All registered utility ids, in registry order.
+pub fn utility_ids() -> Vec<&'static str> {
+    descriptors().iter().map(|d| d.id).collect()
+}
+
+/// Validate an effort value against a descriptor's native support.
+/// Returns a useful error listing the supported values when unsupported.
+pub fn validate_effort(descriptor: &AdapterDescriptor, effort: Effort) -> Result<()> {
+    if descriptor.efforts.is_empty() {
+        anyhow::bail!(
+            "utility `{}` does not support effort levels; drop the `@{effort}` suffix",
+            descriptor.id
+        );
+    }
+    if !descriptor.supports_effort(effort) {
+        let supported: Vec<&str> = descriptor.efforts.iter().map(Effort::as_str).collect();
+        anyhow::bail!(
+            "effort `{effort}` is not supported by `{}`; supported: {}",
+            descriptor.id,
+            supported.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// How the prompt reaches a CLI adapter's child process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PromptDelivery {
+    /// The prompt is appended as the final argv element.
+    Arg,
+    /// The prompt is written to the child's stdin.
+    Stdin,
+}
+
+/// A fully-specified CLI invocation: an explicit argv template plus the
+/// prompt delivery mode. Never a shell string.
+#[derive(Debug, Clone)]
+pub struct CommandSpec {
+    /// Executable name or path (looked up on PATH if not absolute).
+    pub program: String,
+    /// Arguments, in order, each passed verbatim — no shell expansion.
+    pub args: Vec<String>,
+    /// How the per-completion prompt is delivered.
+    pub prompt_delivery: PromptDelivery,
+    /// Explicit environment overrides for the child. Values are never logged.
+    pub env: Vec<(String, String)>,
+    /// Exact adapter-specific parent variables that may be inherited.
+    pub inherit_env: Vec<String>,
+    /// Insert `--` before an argv-delivered prompt so a leading hyphen cannot
+    /// be interpreted as another CLI flag. Used only by CLIs whose prompt is
+    /// a positional argument (not an option value).
+    end_of_options_before_prompt: bool,
+}
+
+impl CommandSpec {
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            prompt_delivery: PromptDelivery::Arg,
+            env: Vec::new(),
+            inherit_env: Vec::new(),
+            end_of_options_before_prompt: false,
+        }
+    }
+
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn prompt_delivery(mut self, delivery: PromptDelivery) -> Self {
+        self.prompt_delivery = delivery;
+        self
+    }
+
+    /// Add an explicit environment override for the child.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    pub fn inherit_env(mut self, key: impl Into<String>) -> Self {
+        self.inherit_env.push(key.into());
+        self
+    }
+
+    pub fn end_of_options_before_prompt(mut self) -> Self {
+        self.end_of_options_before_prompt = true;
+        self
+    }
+
+    /// The full argv vector (program first), without the prompt, for tests
+    /// and receipts.
+    pub fn argv(&self) -> Vec<String> {
+        std::iter::once(self.program.clone()).chain(self.args.iter().cloned()).collect()
+    }
+
+    /// Materialize a runnable [`ProcessSpec`] for one prompt.
+    fn process_spec(&self, prompt: &str) -> ProcessSpec {
+        let mut spec = ProcessSpec::new(self.program.clone()).args(self.args.clone());
+        match self.prompt_delivery {
+            PromptDelivery::Arg => {
+                if self.end_of_options_before_prompt {
+                    spec = spec.arg("--");
+                }
+                spec = spec.arg(prompt);
+            }
+            PromptDelivery::Stdin => spec = spec.stdin(prompt),
+        }
+        for (key, value) in &self.env {
+            spec = spec.env(key.clone(), value.clone());
+        }
+        for key in &self.inherit_env {
+            spec = spec.inherit_env(key.clone());
+        }
+        spec
+    }
+}
+
+/// Per-adapter overrides for discovery and execution. Everything defaults
+/// to the descriptor's values; overrides never change argv shape, only
+/// where the binary lives and how the process is bounded.
+#[derive(Debug, Clone, Default)]
+pub struct AdapterOverrides {
+    /// Explicit path to the adapter binary (skips PATH lookup).
+    pub binary_path: Option<PathBuf>,
+    /// Process limits (timeout, output caps) for command adapters.
+    pub limits: Option<ProcessLimits>,
+    /// Explicit environment values from `[adapters.<id>.env]`.
+    pub env: Vec<(String, String)>,
+}
+
+/// An [`LlmProvider`] that runs a CLI adapter via [`run_argv`]: explicit
+/// argv, scrubbed environment, never a shell.
+pub struct CommandProvider {
+    spec: CommandSpec,
+    limits: ProcessLimits,
+    options: ProviderOptions,
+}
+
+impl CommandProvider {
+    pub fn new(spec: CommandSpec) -> Self {
+        Self { spec, limits: ProcessLimits::default(), options: ProviderOptions::default() }
+    }
+
+    pub fn with_limits(mut self, limits: ProcessLimits) -> Self {
+        self.limits = limits;
+        self.options.timeout = limits.timeout;
+        self.options.max_output_bytes = limits.max_stdout_bytes;
+        self
+    }
+
+    pub fn spec(&self) -> &CommandSpec {
+        &self.spec
+    }
+
+    /// Run one completion and return the raw process output.
+    pub async fn run(&self, prompt: &str) -> Result<ProcessOutput> {
+        let spec = self.spec.process_spec(prompt);
+        run_argv(&spec, &self.limits).await
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for CommandProvider {
+    async fn complete(&self, prompt: &str, system: Option<&str>) -> Result<String> {
+        let prompt = match system {
+            Some(system) => format!("System instructions:\n{system}\n\nUser request:\n{prompt}"),
+            None => prompt.to_string(),
+        };
+        let out = self.run(&prompt).await?;
+        Ok(out.stdout.trim_end().to_string())
+    }
+
+    fn transport(&self) -> Transport {
+        Transport::Command
+    }
+
+    fn options(&self) -> ProviderOptions {
+        self.options
+    }
+}
+
+/// ACP is a recognized transport that this build does not implement. Every
+/// completion returns an explicit unsupported error.
+pub struct AcpProvider {
+    model: String,
+}
+
+impl AcpProvider {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self { model: model.into() }
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for AcpProvider {
+    async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+        anyhow::bail!(
+            "ACP transport is recognized but not supported by this build (member model `{}`)",
+            self.model
+        )
+    }
+
+    fn transport(&self) -> Transport {
+        Transport::Acp
+    }
+}
+
+/// The environment variable the Kimi CLI (≥ 0.27, verified against the
+/// installed 0.27.0 binary and the official docs) reads to force a thinking
+/// effort on the wire. Non-secret; applied to the child process only.
+pub const KIMI_EFFORT_ENV: &str = "KIMI_MODEL_THINKING_EFFORT";
+
+/// A fully-built command-adapter invocation: the argv template plus any
+/// non-secret environment overrides. Effort is already baked into the argv
+/// (or the environment, for Kimi); the prompt is supplied per completion by
+/// [`CommandProvider`].
+pub struct CommandInvocation {
+    pub spec: CommandSpec,
+}
+
+impl CommandInvocation {
+    /// The full argv vector (program first), for tests and receipts.
+    pub fn argv(&self) -> Vec<String> {
+        self.spec.argv()
+    }
+}
+
+/// Build the exact invocation for a CLI adapter member. Evidence:
+///
+/// - claude: `claude -p --model <m> [--effort <e>] <prompt>`
+/// - codex: `codex exec [--skip-git-repo-check] [-m <m>]
+///   [-c model_reasoning_effort="<e>"]`, prompt on stdin; model `default`
+///   omits `-m` entirely
+/// - kimi: `kimi -m <m> -p <prompt>`; effort is delivered via the
+///   non-secret [`KIMI_EFFORT_ENV`] environment override — the Kimi CLI
+///   (verified 0.27.0) has no `--config-file` or effort argv flag, and its
+///   authenticated state under `$KIMI_CODE_HOME` is left completely untouched
+/// - opencode: `opencode run -m <provider/model> [--variant <e>] <prompt>`
+/// - grok: `grok --model <m> [--reasoning-effort <e>] --sandbox read-only
+///   --no-subagents --yolo --output-format plain -p <prompt>`
+pub fn build_invocation(member: &MemberSpec) -> Result<CommandInvocation> {
+    build_invocation_with(member, &AdapterOverrides::default())
+}
+
+/// Like [`build_invocation`], with an optional binary path override.
+pub fn build_invocation_with(
+    member: &MemberSpec,
+    overrides: &AdapterOverrides,
+) -> Result<CommandInvocation> {
+    member.validate()?;
+    let descriptor = member.utility.descriptor();
+    if descriptor.transport != Transport::Command {
+        anyhow::bail!("`{}` is not a command adapter", descriptor.id);
+    }
+    let program = overrides
+        .binary_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| descriptor.binary.expect("command adapter has binary").to_string());
+    let model = member.model.as_str();
+    let effort = member.effort;
+
+    let mut spec = match member.utility {
+        Utility::Claude => {
+            let mut spec = CommandSpec::new(program)
+                .args(["-p", "--model", model])
+                .end_of_options_before_prompt();
+            if let Some(e) = effort {
+                spec = spec.args(["--effort", e.as_str()]);
+            }
+            spec
+        }
+        Utility::Codex => {
+            let mut spec = CommandSpec::new(program)
+                .args(["exec", "--skip-git-repo-check"])
+                .prompt_delivery(PromptDelivery::Stdin);
+            if model != "default" {
+                spec = spec.args(["-m", model]);
+            }
+            if let Some(e) = effort {
+                spec = spec.args(["-c"]).args([format!("model_reasoning_effort=\"{e}\"")]);
+            }
+            spec
+        }
+        Utility::Kimi => {
+            let mut spec = CommandSpec::new(program).args(["-m", model]);
+            if let Some(e) = effort {
+                // Supported per-invocation effort channel: a non-secret env
+                // override the Kimi CLI reads at startup. Never argv (no flag
+                // exists) and never a config file (`--config-file` does not
+                // exist; writing one would not be read).
+                spec = spec.env(KIMI_EFFORT_ENV, e.as_str());
+            }
+            // `-p` takes the prompt as its value; CommandProvider appends it
+            // as the final argv element.
+            spec.args(["-p"])
+        }
+        Utility::Opencode => {
+            let mut spec =
+                CommandSpec::new(program).args(["run", "-m", model]).end_of_options_before_prompt();
+            if let Some(e) = effort {
+                spec = spec.args(["--variant", e.as_str()]);
+            }
+            spec
+        }
+        Utility::Grok => {
+            let mut spec = CommandSpec::new(program).args([
+                "--model",
+                model,
+                "--yolo",
+                "--sandbox",
+                "read-only",
+                "--no-subagents",
+                "--output-format",
+                "plain",
+            ]);
+            if let Some(e) = effort {
+                spec = spec.args(["--reasoning-effort", e.as_str()]);
+            }
+            // `-p` consumes the following argv element as the prompt. Keep it
+            // last so intervening flags cannot become the prompt value.
+            spec.args(["-p"])
+        }
+        other => anyhow::bail!("no command adapter registered for `{other}`"),
+    };
+
+    // Inherit only variables that this exact adapter can legitimately use.
+    // The subprocess runtime still clears every other ambient variable.
+    for key in inherited_env_for(member.utility) {
+        spec = spec.inherit_env(key);
+    }
+    for (key, value) in &overrides.env {
+        spec = spec.env(key.clone(), value.clone());
+    }
+
+    Ok(CommandInvocation { spec })
+}
+
+const COMMON_COMMAND_ENV: &[&str] = &[
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "NODE_EXTRA_CA_CERTS",
+];
+
+fn inherited_env_for(utility: Utility) -> Vec<&'static str> {
+    let mut names = COMMON_COMMAND_ENV.to_vec();
+    names.extend(match utility {
+        Utility::Claude => &[
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "CLAUDE_CONFIG_DIR",
+        ][..],
+        Utility::Codex => &["OPENAI_API_KEY", "OPENAI_BASE_URL", "CODEX_HOME"][..],
+        Utility::Kimi => &["KIMI_CODE_HOME"][..],
+        Utility::Opencode => &[
+            "OPENCODE_CONFIG",
+            "OPENCODE_CONFIG_DIR",
+            "ZAI_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ][..],
+        Utility::Grok => &["GROK_HOME", "GROK_DISABLE_AUTOUPDATER", "XAI_API_KEY"][..],
+        _ => &[][..],
+    });
+    names
+}
+
+/// Build a ready-to-use provider for a validated [`MemberSpec`].
+///
+/// Command adapters return a [`CommandProvider`]; local servers return an
+/// [`HttpProvider::ollama`] / [`HttpProvider::lmstudio`]; remote APIs return
+/// an [`HttpProvider`] keyed from the descriptor's `api_key_env`; ACP
+/// returns the honestly-unsupported [`AcpProvider`].
+pub fn provider_for(member: &MemberSpec) -> Result<Box<dyn LlmProvider>> {
+    provider_for_with(member, &AdapterOverrides::default())
+}
+
+/// Like [`provider_for`], with per-adapter overrides.
+pub fn provider_for_with(
+    member: &MemberSpec,
+    overrides: &AdapterOverrides,
+) -> Result<Box<dyn LlmProvider>> {
+    member.validate()?;
+    match member.utility.descriptor().transport {
+        Transport::Command => {
+            let invocation = build_invocation_with(member, overrides)?;
+            let mut provider = CommandProvider::new(invocation.spec);
+            if let Some(limits) = overrides.limits {
+                provider = provider.with_limits(limits);
+            }
+            Ok(Box::new(provider))
+        }
+        Transport::LocalServer => {
+            let mut provider = match member.utility {
+                Utility::Ollama => HttpProvider::ollama(member.model.clone()),
+                Utility::Lmstudio => HttpProvider::lmstudio(member.model.clone()),
+                other => anyhow::bail!("no local-server adapter registered for `{other}`"),
+            };
+            if let Some(limits) = overrides.limits {
+                provider = provider.with_timeout(limits.timeout);
+            }
+            Ok(Box::new(provider))
+        }
+        Transport::Api => {
+            let descriptor = member.utility.descriptor();
+            let env = descriptor.api_key_env.expect("api adapter has api_key_env");
+            let key = std::env::var(env).map_err(|_| {
+                anyhow::anyhow!(
+                    "utility `{}` requires the `{env}` environment variable",
+                    member.utility
+                )
+            })?;
+            let mut provider = match member.utility {
+                Utility::Gemini => HttpProvider::gemini(key, member.model.clone()),
+                other => anyhow::bail!("no api adapter registered for `{other}`"),
+            };
+            if let Some(limits) = overrides.limits {
+                provider = provider.with_timeout(limits.timeout);
+            }
+            Ok(Box::new(provider))
+        }
+        Transport::Acp => Ok(Box::new(AcpProvider::new(member.model.clone()))),
+    }
+}
+
+/// How reachable an adapter is right now, determined without any credentials.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Readiness {
+    /// Binary found on PATH, local server port accepting connections, or the
+    /// API key environment variable is set.
+    Ready,
+    /// CLI binary not found on PATH.
+    MissingBinary(&'static str),
+    /// Local server not listening on its well-known port.
+    ServerDown(&'static str),
+    /// Remote API whose key environment variable is unset or empty.
+    MissingApiKey(&'static str),
+    /// Recognized but not implemented (e.g. ACP).
+    Unsupported(String),
+}
+
+impl Readiness {
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready)
+    }
+}
+
+impl std::fmt::Display for Readiness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ready => f.write_str("ready"),
+            Self::MissingBinary(bin) => write!(f, "missing binary `{bin}`"),
+            Self::ServerDown(addr) => write!(f, "no server at {addr}"),
+            Self::MissingApiKey(env) => write!(f, "missing API key `{env}`"),
+            Self::Unsupported(why) => write!(f, "unsupported: {why}"),
+        }
+    }
+}
+
+/// A descriptor paired with its current readiness.
+#[derive(Debug, Clone)]
+pub struct Discovered {
+    pub descriptor: &'static AdapterDescriptor,
+    pub readiness: Readiness,
+}
+
+/// Discover every known adapter without reading any credentials: CLI
+/// adapters check PATH, local servers probe their ports, remote APIs check
+/// only that their key environment variable is set (never its value — the
+/// CLI's dotenv loading runs before discovery, so `.env` keys count), ACP
+/// reports its honest unsupported status.
+pub async fn discover() -> Vec<Discovered> {
+    let mut out = Vec::new();
+    for d in descriptors() {
+        let readiness = match d.transport {
+            Transport::Command => binary_readiness(d.binary.expect("command adapter has binary")),
+            Transport::LocalServer => {
+                port_readiness(d.base_url.expect("local-server adapter has base url")).await
+            }
+            Transport::Api => {
+                api_key_readiness(d.api_key_env.expect("api adapter has api_key_env"))
+            }
+            Transport::Acp => Readiness::Unsupported(
+                "ACP transport is recognized but not implemented in this build".to_string(),
+            ),
+        };
+        out.push(Discovered { descriptor: d, readiness });
+    }
+    out
+}
+
+/// Remote-API readiness: honest about the key environment variable. Only
+/// presence is checked — the value is never read, logged, or probed. An
+/// explicit env var or one loaded from a `.env` file (the CLI loads dotenv
+/// before any command runs) both count; an unset or empty variable does not.
+fn api_key_readiness(api_key_env: &'static str) -> Readiness {
+    api_key_readiness_value(api_key_env, std::env::var_os(api_key_env))
+}
+
+fn api_key_readiness_value(
+    api_key_env: &'static str,
+    value: Option<std::ffi::OsString>,
+) -> Readiness {
+    match value {
+        Some(value) if !value.is_empty() => Readiness::Ready,
+        _ => Readiness::MissingApiKey(api_key_env),
+    }
+}
+
+fn binary_readiness(binary: &'static str) -> Readiness {
+    if find_on_path(binary).is_some() { Readiness::Ready } else { Readiness::MissingBinary(binary) }
+}
+
+async fn port_readiness(base_url: &'static str) -> Readiness {
+    let authority = base_url
+        .strip_prefix("http://")
+        .or_else(|| base_url.strip_prefix("https://"))
+        .unwrap_or(base_url);
+    let authority = authority.split('/').next().unwrap_or(authority);
+    let connect = tokio::net::TcpStream::connect(authority);
+    match tokio::time::timeout(Duration::from_millis(300), connect).await {
+        Ok(Ok(_)) => Readiness::Ready,
+        _ => Readiness::ServerDown(base_url),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn desc(id: &str) -> &'static AdapterDescriptor {
+        descriptor(id).unwrap()
+    }
+
+    fn member(spec: &str) -> MemberSpec {
+        MemberSpec::parse(spec).unwrap()
+    }
+
+    #[test]
+    fn registry_covers_all_transports_and_utilities() {
+        for transport in
+            [Transport::Command, Transport::LocalServer, Transport::Api, Transport::Acp]
+        {
+            assert!(
+                descriptors().iter().any(|d| d.transport == transport),
+                "no adapter descriptor for transport {transport}"
+            );
+        }
+        let ids = utility_ids();
+        for expected in
+            ["claude", "codex", "kimi", "opencode", "ollama", "lmstudio", "gemini", "grok", "acp"]
+        {
+            assert!(ids.contains(&expected), "missing adapter `{expected}`");
+        }
+    }
+
+    #[test]
+    fn descriptor_effort_support_is_exact() {
+        assert_eq!(desc("claude").efforts, [Low, Medium, High, Xhigh, Max]);
+        assert_eq!(desc("codex").efforts, [Minimal, Low, Medium, High, Xhigh]);
+        assert_eq!(desc("kimi").efforts, [Low, High, Max]);
+        assert_eq!(desc("opencode").efforts, [Minimal, Low, Medium, High, Xhigh, Max]);
+        assert_eq!(desc("grok").efforts, [Low, Medium, High]);
+        assert!(desc("ollama").efforts.is_empty());
+        assert!(desc("lmstudio").efforts.is_empty());
+    }
+
+    #[test]
+    fn member_spec_parses_and_round_trips() {
+        let m = member("opencode:zai-coding-plan/glm-5.2@xhigh");
+        assert_eq!(m.utility, Utility::Opencode);
+        assert_eq!(m.model, "zai-coding-plan/glm-5.2");
+        assert_eq!(m.effort, Some(Effort::Xhigh));
+        assert_eq!(m.to_string(), "opencode:zai-coding-plan/glm-5.2@xhigh");
+        assert_eq!(member("ollama:llama3.2:latest").model, "llama3.2:latest");
+    }
+
+    #[test]
+    fn member_spec_rejects_bad_input() {
+        assert!(MemberSpec::parse("opus@high").is_err()); // missing `:`
+        assert!(MemberSpec::parse("bogus:model@high").is_err()); // unknown utility
+        assert!(MemberSpec::parse("claude:@high").is_err()); // empty model
+        assert!(MemberSpec::parse("claude:mo del").is_err()); // whitespace
+        assert!(MemberSpec::parse("claude:model@ludicrous").is_err()); // bad effort
+    }
+
+    #[test]
+    fn member_spec_serde_validates_and_preserves_exact_model() {
+        let json = r#"{"utility":"claude","model":"claude-opus-4-1-20250805","effort":"xhigh"}"#;
+        let m: MemberSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(m.model, "claude-opus-4-1-20250805");
+        assert_eq!(m.effort, Some(Effort::Xhigh));
+        let bad = r#"{"utility":"kimi","model":"k3","effort":"medium"}"#;
+        assert!(serde_json::from_str::<MemberSpec>(bad).is_err());
+    }
+
+    #[test]
+    fn claude_argv_uses_print_model_and_effort_flags() {
+        let inv = build_invocation(&member("claude:opus@xhigh")).unwrap();
+        assert_eq!(inv.argv(), ["claude", "-p", "--model", "opus", "--effort", "xhigh"]);
+        assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+        assert!(inv.spec.inherit_env.contains(&"CLAUDE_CONFIG_DIR".to_string()));
+        assert!(inv.spec.inherit_env.contains(&"HTTPS_PROXY".to_string()));
+    }
+
+    #[test]
+    fn claude_argv_without_effort_omits_flag() {
+        let inv = build_invocation(&member("claude:opus")).unwrap();
+        assert_eq!(inv.argv(), ["claude", "-p", "--model", "opus"]);
+    }
+
+    #[test]
+    fn codex_argv_uses_config_override_for_effort() {
+        let inv = build_invocation(&member("codex:gpt-5.6-sol@xhigh")).unwrap();
+        assert_eq!(
+            inv.argv(),
+            [
+                "codex",
+                "exec",
+                "--skip-git-repo-check",
+                "-m",
+                "gpt-5.6-sol",
+                "-c",
+                "model_reasoning_effort=\"xhigh\""
+            ]
+        );
+        assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Stdin);
+    }
+
+    #[test]
+    fn codex_default_model_omits_model_flag() {
+        let inv = build_invocation(&member("codex:default@minimal")).unwrap();
+        assert_eq!(
+            inv.argv(),
+            ["codex", "exec", "--skip-git-repo-check", "-c", "model_reasoning_effort=\"minimal\""]
+        );
+    }
+
+    #[test]
+    fn codex_rejects_max_effort() {
+        let err = MemberSpec::parse("codex:gpt-5@max").unwrap_err();
+        assert!(err.to_string().contains("minimal, low, medium, high, xhigh"));
+    }
+
+    #[test]
+    fn kimi_effort_uses_env_override_never_argv_or_files() {
+        let inv = build_invocation(&member("kimi:kimi-code/k3@high")).unwrap();
+        let argv = inv.argv();
+        // The effort value itself never appears on argv, and no config-file
+        // flag is emitted (the installed Kimi CLI 0.27.0 rejects it).
+        assert!(!argv.iter().any(|a| a == "high"));
+        assert!(!argv.iter().any(|a| a == "--config-file"));
+        assert_eq!(argv, ["kimi", "-m", "kimi-code/k3", "-p"]);
+        // Effort is delivered via the documented, non-secret env override.
+        assert_eq!(inv.spec.env, vec![(KIMI_EFFORT_ENV.to_string(), "high".to_string())],);
+    }
+
+    #[test]
+    fn kimi_prompt_is_delivered_as_final_argv_element() {
+        let inv = build_invocation(&member("kimi:kimi-code/k3")).unwrap();
+        assert_eq!(inv.argv(), ["kimi", "-m", "kimi-code/k3", "-p"]);
+        assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+        assert!(inv.spec.env.is_empty(), "no effort → no env override");
+    }
+
+    #[test]
+    fn kimi_rejects_unsupported_effort_with_supported_list() {
+        let err = MemberSpec::parse("kimi:k3@xhigh").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("xhigh"), "got: {msg}");
+        assert!(msg.contains("low, high, max"), "got: {msg}");
+    }
+
+    #[test]
+    fn opencode_argv_uses_variant_for_effort() {
+        let inv = build_invocation(&member("opencode:zai-coding-plan/glm-5.2@xhigh")).unwrap();
+        assert_eq!(
+            inv.argv(),
+            ["opencode", "run", "-m", "zai-coding-plan/glm-5.2", "--variant", "xhigh"]
+        );
+        assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+    }
+
+    #[test]
+    fn grok_argv_uses_subscription_cli_in_read_only_mode() {
+        let inv = build_invocation(&member("grok:grok-4.5@high")).unwrap();
+        assert_eq!(
+            inv.argv(),
+            [
+                "grok",
+                "--model",
+                "grok-4.5",
+                "--yolo",
+                "--sandbox",
+                "read-only",
+                "--no-subagents",
+                "--output-format",
+                "plain",
+                "--reasoning-effort",
+                "high",
+                "-p",
+            ]
+        );
+        assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+        assert!(inv.spec.inherit_env.contains(&"GROK_HOME".to_string()));
+    }
+
+    #[test]
+    fn grok_rejects_effort_above_installed_cli_contract() {
+        let error = MemberSpec::parse("grok:grok-4.5@xhigh").unwrap_err().to_string();
+        assert!(error.contains("low, medium, high"), "got: {error}");
+    }
+
+    #[test]
+    fn effort_on_non_effort_adapter_is_rejected() {
+        let err = MemberSpec::parse("ollama:llama3.2@high").unwrap_err();
+        assert!(err.to_string().contains("does not support effort"));
+    }
+
+    #[test]
+    fn binary_path_override_replaces_program_only() {
+        let overrides =
+            AdapterOverrides { binary_path: Some("/opt/claude".into()), ..Default::default() };
+        let inv = build_invocation_with(&member("claude:opus@max"), &overrides).unwrap();
+        assert_eq!(inv.argv(), ["/opt/claude", "-p", "--model", "opus", "--effort", "max"]);
+    }
+
+    #[test]
+    fn configured_adapter_environment_reaches_only_that_invocation() {
+        let overrides = AdapterOverrides {
+            env: vec![("CUSTOM_ENDPOINT".into(), "https://example.invalid".into())],
+            ..Default::default()
+        };
+        let inv = build_invocation_with(&member("claude:opus@high"), &overrides).unwrap();
+        assert!(
+            inv.spec.env.contains(&("CUSTOM_ENDPOINT".into(), "https://example.invalid".into()))
+        );
+        let plain = build_invocation(&member("codex:default@high")).unwrap();
+        assert!(!plain.spec.env.iter().any(|(key, _)| key == "CUSTOM_ENDPOINT"));
+    }
+
+    #[test]
+    fn positional_prompts_starting_with_hyphen_are_not_parsed_as_flags() {
+        for spec in ["claude:opus@high", "opencode:zai-coding-plan/glm-5.2@high"] {
+            let invocation = build_invocation(&member(spec)).unwrap();
+            let process = invocation.spec.process_spec("--not-a-real-flag");
+            assert_eq!(
+                &process.args[process.args.len() - 2..],
+                ["--", "--not-a-real-flag"],
+                "{spec}"
+            );
+        }
+
+        let kimi = build_invocation(&member("kimi:kimi-code/k3@high")).unwrap();
+        let process = kimi.spec.process_spec("--still-the-prompt");
+        assert_eq!(&process.args[process.args.len() - 2..], ["-p", "--still-the-prompt"]);
+    }
+
+    #[tokio::test]
+    async fn command_provider_runs_explicit_argv_without_shell() {
+        let spec = CommandSpec::new("/bin/echo").args(["-n"]).prompt_delivery(PromptDelivery::Arg);
+        let provider = CommandProvider::new(spec);
+        assert_eq!(provider.complete("hello", None).await.unwrap(), "hello");
+        assert_eq!(provider.transport(), Transport::Command);
+
+        let spec = CommandSpec::new("/bin/cat").prompt_delivery(PromptDelivery::Stdin);
+        let provider = CommandProvider::new(spec);
+        assert_eq!(provider.complete("piped", None).await.unwrap(), "piped");
+
+        let spec = CommandSpec::new("/bin/cat").prompt_delivery(PromptDelivery::Stdin);
+        let provider = CommandProvider::new(spec);
+        let output = provider.complete("question", Some("be precise")).await.unwrap();
+        assert!(output.contains("System instructions:\nbe precise"));
+        assert!(output.contains("User request:\nquestion"));
+    }
+
+    #[tokio::test]
+    async fn acp_provider_is_explicitly_unsupported() {
+        let provider = AcpProvider::new("some-agent");
+        let err = provider.complete("hi", None).await.unwrap_err();
+        assert!(err.to_string().contains("not supported"));
+        assert_eq!(provider.transport(), Transport::Acp);
+    }
+
+    #[tokio::test]
+    async fn acp_reports_honest_unsupported_status() {
+        let found = discover().await;
+        let acp = found.iter().find(|f| f.descriptor.id == "acp").unwrap();
+        assert!(matches!(acp.readiness, Readiness::Unsupported(_)));
+        assert!(!acp.readiness.is_ready());
+    }
+
+    #[test]
+    fn glm_alias_resolves_to_opencode() {
+        // Legacy member specs used `glm` for the GLM-via-opencode provider.
+        let m = member("glm:zai-coding-plan/glm-5.2@xhigh");
+        assert_eq!(m.utility, Utility::Opencode);
+        // Canonical rendering always uses the real utility id.
+        assert_eq!(m.to_string(), "opencode:zai-coding-plan/glm-5.2@xhigh");
+    }
+
+    #[test]
+    fn api_readiness_is_honest_about_key_presence() {
+        assert_eq!(
+            api_key_readiness_value("CAUCUS_TEST_API_KEY", Some("k".into())),
+            Readiness::Ready
+        );
+        assert_eq!(
+            api_key_readiness_value("CAUCUS_TEST_API_KEY", Some("".into())),
+            Readiness::MissingApiKey("CAUCUS_TEST_API_KEY")
+        );
+        assert_eq!(
+            api_key_readiness_value("CAUCUS_TEST_API_KEY", None),
+            Readiness::MissingApiKey("CAUCUS_TEST_API_KEY")
+        );
+        assert!(!Readiness::MissingApiKey("X").is_ready());
+    }
+
+    #[tokio::test]
+    async fn api_adapter_readiness_matches_key_presence() {
+        let found = discover().await;
+        let d = found.iter().find(|d| d.descriptor.id == "gemini").unwrap();
+        match std::env::var_os("GEMINI_API_KEY") {
+            Some(v) if !v.is_empty() => assert!(d.readiness.is_ready(), "gemini"),
+            _ => assert_eq!(d.readiness, Readiness::MissingApiKey("GEMINI_API_KEY")),
+        }
+
+        let grok = found.iter().find(|d| d.descriptor.id == "grok").unwrap();
+        assert!(matches!(grok.readiness, Readiness::Ready | Readiness::MissingBinary("grok")));
+    }
+
+    #[tokio::test]
+    async fn discovery_includes_every_descriptor() {
+        let found = discover().await;
+        assert_eq!(found.len(), descriptors().len());
+    }
+
+    #[test]
+    fn provider_factory_dispatches_by_transport() {
+        let cli = provider_for(&member("kimi:kimi-code/k3@high")).unwrap();
+        assert_eq!(cli.transport(), Transport::Command);
+
+        let grok = provider_for(&member("grok:grok-4.5@high")).unwrap();
+        assert_eq!(grok.transport(), Transport::Command);
+
+        let local = provider_for(&member("ollama:llama3.2")).unwrap();
+        assert_eq!(local.transport(), Transport::LocalServer);
+
+        let studio = provider_for(&member("lmstudio:qwen2.5-coder")).unwrap();
+        assert_eq!(studio.transport(), Transport::LocalServer);
+
+        let acp = provider_for(&member("acp:some-agent")).unwrap();
+        assert_eq!(acp.transport(), Transport::Acp);
+    }
+
+    #[test]
+    fn http_provider_honors_adapter_timeout_override() {
+        let overrides = AdapterOverrides {
+            limits: Some(ProcessLimits::default().with_timeout(Duration::from_secs(321))),
+            ..Default::default()
+        };
+        let provider = provider_for_with(&member("ollama:llama3.2:latest"), &overrides).unwrap();
+        assert_eq!(provider.options().timeout, Duration::from_secs(321));
+    }
+}

--- a/crates/caucus-core/src/config.rs
+++ b/crates/caucus-core/src/config.rs
@@ -1,0 +1,695 @@
+//! Council configuration: user profiles, built-ins, discovery, resolution.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+pub use crate::adapters::MemberSpec;
+
+/// TOML shape of a single profile under `[profiles.<name>]`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Profile {
+    pub description: Option<String>,
+    pub strategy: Option<String>,
+    pub quorum: Option<usize>,
+    /// Whole-run wall-clock budget.
+    pub deadline_secs: Option<u64>,
+    /// Per-provider request/process timeout. When omitted, `deadline_secs`
+    /// is also the per-request ceiling, then the library default applies.
+    pub request_timeout_secs: Option<u64>,
+    pub budget_usd: Option<f64>,
+    /// Designated judge member (`utility:model@effort`) for judge/debate
+    /// strategies. When unset, the first council member judges.
+    pub judge: Option<String>,
+    #[serde(default)]
+    pub members: Vec<String>,
+}
+
+/// A profile with member strings validated into [`MemberSpec`]s.
+#[derive(Debug, Clone)]
+pub struct Council {
+    pub name: String,
+    pub description: Option<String>,
+    pub members: Vec<MemberSpec>,
+    /// Designated judge, validated like a member. `None` means the first
+    /// member judges.
+    pub judge: Option<MemberSpec>,
+    pub strategy: String,
+    pub quorum: usize,
+    /// Whole-run wall-clock budget.
+    pub deadline_secs: Option<u64>,
+    /// Per-provider request/process timeout.
+    pub request_timeout_secs: Option<u64>,
+    pub budget_usd: Option<f64>,
+}
+
+/// Errors produced while loading, validating, or resolving configuration.
+#[derive(Debug)]
+pub enum ConfigError {
+    Io { path: PathBuf, source: std::io::Error },
+    Parse { source: toml::de::Error },
+    Invalid { message: String },
+    UnknownProfile { name: String },
+    NoDefault,
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => write!(f, "failed to read {}: {source}", path.display()),
+            Self::Parse { source } => write!(f, "invalid TOML: {source}"),
+            Self::Invalid { message } => write!(f, "invalid config: {message}"),
+            Self::UnknownProfile { name } => write!(f, "unknown profile: {name}"),
+            Self::NoDefault => write!(f, "no profile given and no default_profile set"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// Loaded caucus configuration.
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+    pub default_profile: Option<String>,
+    pub profiles: BTreeMap<String, Profile>,
+    /// Per-adapter overrides from `[adapters.<name>]`.
+    pub adapters: BTreeMap<String, toml::Value>,
+    /// Warnings produced by the legacy-schema migration while parsing.
+    /// Empty for files that use only the current schema.
+    pub warnings: Vec<String>,
+}
+
+/// Raw TOML document before profiles are separated from adapter overrides.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    default_profile: Option<String>,
+    #[serde(default)]
+    profiles: BTreeMap<String, Profile>,
+    #[serde(default)]
+    adapters: BTreeMap<String, toml::Value>,
+}
+
+/// Built-in `deep` profile. User profiles shadow built-ins by name.
+const BUILTIN_DEEP_TOML: &str = r#"
+description = "Broad frontier panel judged by a chair"
+strategy = "judge"
+quorum = 3
+deadline_secs = 600
+members = [
+    "claude:opus@xhigh",
+    "claude:claude-fable-5@xhigh",
+    "codex:default@xhigh",
+    "opencode:zai-coding-plan/glm-5.2@xhigh",
+    "kimi:kimi-code/k3@high",
+]
+"#;
+
+/// Built-in profiles, shadowed by user profiles of the same name.
+pub fn builtin_profiles() -> BTreeMap<String, Profile> {
+    let deep: Profile =
+        toml::from_str(BUILTIN_DEEP_TOML).expect("built-in deep profile must parse");
+    BTreeMap::from([("deep".to_string(), deep)])
+}
+
+impl Config {
+    /// Parse a config from a TOML string and validate it.
+    ///
+    /// Legacy profile keys (`models`, `timeout_seconds`, `deadline_seconds`)
+    /// are migrated in memory with recorded [`Config::warnings`]; the file
+    /// on disk is never modified.
+    pub fn from_toml_str(input: &str) -> Result<Self, ConfigError> {
+        let mut doc: toml::Value =
+            toml::from_str(input).map_err(|source| ConfigError::Parse { source })?;
+        let mut warnings = Vec::new();
+        migrate_legacy_profiles(&mut doc, &mut warnings);
+        let raw: RawConfig = doc.try_into().map_err(|source| ConfigError::Parse { source })?;
+        let config = Self {
+            default_profile: raw.default_profile,
+            profiles: raw.profiles,
+            adapters: raw.adapters,
+            warnings,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Load a config from an explicit path. Returns the path and the config.
+    pub fn load(path: &Path) -> Result<(PathBuf, Self), ConfigError> {
+        let text = std::fs::read_to_string(path)
+            .map_err(|source| ConfigError::Io { path: path.to_path_buf(), source })?;
+        Ok((path.to_path_buf(), Self::from_toml_str(&text)?))
+    }
+
+    /// Discover a config file. Search order: explicit path, `./caucus.toml`,
+    /// `$XDG_CONFIG_HOME/caucus/config.toml`, `$HOME/.config/caucus/config.toml`.
+    ///
+    /// An explicit path that does not exist is an error; otherwise a missing
+    /// file simply falls through to the next candidate. Returns `Ok(None)`
+    /// when no candidate exists.
+    pub fn discover(explicit: Option<&Path>) -> Result<Option<(PathBuf, Self)>, ConfigError> {
+        let cwd = env::current_dir()
+            .map_err(|source| ConfigError::Io { path: PathBuf::from("."), source })?;
+        let xdg = env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+        let home = env::var_os("HOME").map(PathBuf::from);
+        Self::discover_in(explicit, &cwd, xdg.as_deref(), home.as_deref())
+    }
+
+    fn discover_in(
+        explicit: Option<&Path>,
+        cwd: &Path,
+        xdg: Option<&Path>,
+        home: Option<&Path>,
+    ) -> Result<Option<(PathBuf, Self)>, ConfigError> {
+        if let Some(path) = explicit {
+            return Self::load(path).map(Some);
+        }
+        let mut candidates = vec![cwd.join("caucus.toml")];
+        if let Some(xdg) = xdg {
+            candidates.push(xdg.join("caucus").join("config.toml"));
+        }
+        if let Some(home) = home {
+            candidates.push(home.join(".config").join("caucus").join("config.toml"));
+        }
+        for path in candidates {
+            if path.is_file() {
+                return Self::load(&path).map(Some);
+            }
+        }
+        Ok(None)
+    }
+
+    /// Check every user profile: members parse, quorum is nonzero and no
+    /// greater than the member count.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        for (name, profile) in &self.profiles {
+            resolve(name, profile)?;
+        }
+        if let Some(default) = &self.default_profile
+            && !self.profiles.contains_key(default)
+            && !builtin_profiles().contains_key(default)
+        {
+            return Err(ConfigError::UnknownProfile { name: default.clone() });
+        }
+        Ok(())
+    }
+
+    /// Resolve a profile by name (or the configured default) into a
+    /// [`Council`]. User profiles shadow built-ins of the same name.
+    pub fn resolve_profile(&self, name: Option<&str>) -> Result<Council, ConfigError> {
+        let name = match name {
+            Some(name) => name.to_string(),
+            None => self.default_profile.clone().ok_or(ConfigError::NoDefault)?,
+        };
+        if let Some(profile) = self.profiles.get(&name) {
+            return resolve(&name, profile);
+        }
+        if let Some(profile) = builtin_profiles().get(&name) {
+            return resolve(&name, profile);
+        }
+        Err(ConfigError::UnknownProfile { name })
+    }
+
+    /// All resolvable profile names, user profiles first, then built-ins.
+    pub fn profile_names(&self) -> Vec<String> {
+        self.list_profiles().into_iter().map(|(name, _)| name).collect()
+    }
+
+    /// All resolvable profiles; user profiles shadow built-ins by name.
+    pub fn list_profiles(&self) -> Vec<(String, Profile)> {
+        let mut merged = builtin_profiles();
+        for (name, profile) in &self.profiles {
+            merged.insert(name.clone(), profile.clone());
+        }
+        merged.into_iter().collect()
+    }
+
+    /// Adapter-specific overrides from `[adapters.<name>]`, if any.
+    pub fn adapter_config(&self, name: &str) -> Option<&toml::Value> {
+        self.adapters.get(name)
+    }
+}
+
+/// Validate a profile and build its [`Council`].
+fn resolve(name: &str, profile: &Profile) -> Result<Council, ConfigError> {
+    let members: Vec<MemberSpec> = profile
+        .members
+        .iter()
+        .map(|raw| {
+            raw.parse().map_err(|_| ConfigError::Invalid {
+                message: format!("profile `{name}`: cannot parse member `{raw}`"),
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let judge = profile
+        .judge
+        .as_ref()
+        .map(|raw| {
+            raw.parse::<MemberSpec>().map_err(|_| ConfigError::Invalid {
+                message: format!("profile `{name}`: cannot parse judge `{raw}`"),
+            })
+        })
+        .transpose()?;
+    let quorum = profile.quorum.unwrap_or(members.len());
+    if quorum == 0 || quorum > members.len() {
+        return Err(ConfigError::Invalid {
+            message: format!(
+                "profile `{name}`: quorum {quorum} must be nonzero and no greater than member count {}",
+                members.len()
+            ),
+        });
+    }
+    for (label, value) in [
+        ("deadline_secs", profile.deadline_secs),
+        ("request_timeout_secs", profile.request_timeout_secs),
+    ] {
+        if value == Some(0) {
+            return Err(ConfigError::Invalid {
+                message: format!("profile `{name}`: {label} must be at least 1"),
+            });
+        }
+    }
+    let strategy = profile.strategy.clone().unwrap_or_else(|| "judge".to_string());
+    crate::strategy_from_name(&strategy)
+        .map_err(|error| ConfigError::Invalid { message: format!("profile `{name}`: {error}") })?;
+    Ok(Council {
+        name: name.to_string(),
+        description: profile.description.clone(),
+        members,
+        judge,
+        strategy,
+        quorum,
+        deadline_secs: profile.deadline_secs,
+        request_timeout_secs: profile.request_timeout_secs,
+        budget_usd: profile.budget_usd,
+    })
+}
+
+/// Migrate legacy profile keys in a parsed TOML document, in memory only.
+///
+/// The previous schema used `models` (member list), `timeout_seconds`
+/// (per-request timeout), and `deadline_seconds` (overall run deadline);
+/// the current schema uses `members`, `request_timeout_secs`, and
+/// `deadline_secs` respectively.
+/// Every migration records a warning — nothing is dropped silently.
+fn migrate_legacy_profiles(doc: &mut toml::Value, warnings: &mut Vec<String>) {
+    let Some(profiles) = doc.get_mut("profiles").and_then(toml::Value::as_table_mut) else {
+        return;
+    };
+    for (name, profile) in profiles.iter_mut() {
+        let Some(table) = profile.as_table_mut() else { continue };
+
+        // `models` -> `members`, migrating legacy member strings.
+        if let Some(models) = table.remove("models") {
+            if table.contains_key("members") {
+                warnings.push(format!(
+                    "profile `{name}`: both `models` and `members` are set; \
+                     using `members` and ignoring the legacy `models` list"
+                ));
+            } else if let Some(entries) = models.as_array() {
+                let migrated = entries
+                    .iter()
+                    .map(|entry| match entry.as_str() {
+                        Some(spec) => {
+                            toml::Value::String(migrate_legacy_member(name, spec, warnings))
+                        }
+                        None => entry.clone(),
+                    })
+                    .collect();
+                table.insert("members".to_string(), toml::Value::Array(migrated));
+                warnings.push(format!(
+                    "profile `{name}`: legacy key `models` was renamed to `members`; \
+                     rename it in the file to silence this warning"
+                ));
+            } else {
+                // Wrong type: put it back so validation reports it honestly.
+                table.insert("models".to_string(), models);
+            }
+        }
+
+        // A `judge` pin keeps its meaning: it names the judging member.
+        if let Some(judge) = table.get("judge").and_then(toml::Value::as_str) {
+            let migrated = migrate_legacy_member(name, judge, warnings);
+            if migrated != judge {
+                table.insert("judge".to_string(), toml::Value::String(migrated));
+            }
+        }
+
+        // `timeout_seconds` was the per-request timeout.
+        if let Some(timeout) = table.remove("timeout_seconds") {
+            if table.contains_key("request_timeout_secs") {
+                warnings.push(format!(
+                    "profile `{name}`: legacy `timeout_seconds` ignored because \
+                     `request_timeout_secs` is also set"
+                ));
+            } else {
+                table.insert("request_timeout_secs".to_string(), timeout);
+                warnings.push(format!(
+                    "profile `{name}`: legacy `timeout_seconds` now maps to \
+                     `request_timeout_secs`; rename it in the file to silence this warning"
+                ));
+            }
+        }
+
+        // `deadline_seconds` was the overall run deadline.
+        if let Some(deadline) = table.remove("deadline_seconds") {
+            if table.contains_key("deadline_secs") {
+                warnings.push(format!(
+                    "profile `{name}`: legacy `deadline_seconds` ignored because \
+                     `deadline_secs` is also set"
+                ));
+            } else {
+                table.insert("deadline_secs".to_string(), deadline);
+                warnings.push(format!(
+                    "profile `{name}`: legacy `deadline_seconds` now maps to `deadline_secs` \
+                     (whole-run deadline); rename it in the file to silence this warning"
+                ));
+            }
+        }
+    }
+}
+
+/// Migrate one legacy member string. Legacy entries could omit the model
+/// pin entirely (`codex@xhigh`), which meant the utility's default model;
+/// the `glm` utility alias is handled by the [`crate::adapters::Utility`]
+/// parser itself.
+fn migrate_legacy_member(profile: &str, spec: &str, warnings: &mut Vec<String>) -> String {
+    if spec.starts_with("glm:") {
+        warnings.push(format!(
+            "profile `{profile}`: utility alias `glm` resolves to `opencode`; \
+             update the pin to `opencode:...` to silence this warning"
+        ));
+    }
+    if spec.contains(':') {
+        return spec.to_string();
+    }
+    let migrated = match spec.rsplit_once('@') {
+        Some((utility, effort)) if !effort.is_empty() => format!("{utility}:default@{effort}"),
+        _ => format!("{spec}:default"),
+    };
+    warnings.push(format!(
+        "profile `{profile}`: legacy member `{spec}` has no model pin; \
+         interpreted as `{migrated}`"
+    ));
+    migrated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_toml() {
+        let toml = r#"
+default_profile = "local"
+
+[profiles.local]
+description = "cheap panel"
+strategy = "majority-vote"
+quorum = 2
+deadline_secs = 120
+budget_usd = 1.5
+members = ["kimi:kimi-code/k3@high", "codex:default@xhigh"]
+
+[adapters.kimi]
+cli_path = "/usr/local/bin/kimi"
+"#;
+        let config = Config::from_toml_str(toml).unwrap();
+        assert_eq!(config.default_profile.as_deref(), Some("local"));
+        let council = config.resolve_profile(None).unwrap();
+        assert_eq!(council.name, "local");
+        assert_eq!(council.description.as_deref(), Some("cheap panel"));
+        assert_eq!(council.strategy, "majority-vote");
+        assert_eq!(council.quorum, 2);
+        assert_eq!(council.deadline_secs, Some(120));
+        assert_eq!(council.budget_usd, Some(1.5));
+        assert_eq!(council.members.len(), 2);
+        assert_eq!(
+            config.adapter_config("kimi").unwrap().get("cli_path").unwrap().as_str(),
+            Some("/usr/local/bin/kimi")
+        );
+    }
+
+    #[test]
+    fn metadata_defaults_apply() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.min]
+members = ["codex:default@xhigh", "kimi:kimi-code/k3@high"]
+"#,
+        )
+        .unwrap();
+        let council = config.resolve_profile(Some("min")).unwrap();
+        assert_eq!(council.strategy, "judge");
+        assert_eq!(council.quorum, 2);
+        assert_eq!(council.description, None);
+        assert_eq!(council.deadline_secs, None);
+        assert_eq!(council.budget_usd, None);
+    }
+
+    #[test]
+    fn builtin_deep_is_exact() {
+        let config = Config::default();
+        let council = config.resolve_profile(Some("deep")).unwrap();
+        let rendered: Vec<String> = council.members.iter().map(|m| m.to_string()).collect();
+        assert_eq!(
+            rendered,
+            vec![
+                "claude:opus@xhigh",
+                "claude:claude-fable-5@xhigh",
+                "codex:default@xhigh",
+                "opencode:zai-coding-plan/glm-5.2@xhigh",
+                "kimi:kimi-code/k3@high",
+            ]
+        );
+        assert_eq!(council.strategy, "judge");
+        assert_eq!(council.quorum, 3);
+        assert_eq!(council.deadline_secs, Some(600));
+    }
+
+    #[test]
+    fn user_profile_shadows_builtin() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.deep]
+quorum = 1
+members = ["codex:default@xhigh"]
+"#,
+        )
+        .unwrap();
+        let council = config.resolve_profile(Some("deep")).unwrap();
+        assert_eq!(council.members.len(), 1);
+        assert_eq!(council.quorum, 1);
+        assert_eq!(config.profile_names().iter().filter(|n| *n == "deep").count(), 1);
+    }
+
+    #[test]
+    fn rejects_zero_and_oversized_quorum() {
+        for quorum in [0, 3] {
+            let toml =
+                format!("[profiles.bad]\nquorum = {quorum}\nmembers = [\"codex:default@xhigh\"]\n");
+            assert!(Config::from_toml_str(&toml).is_err(), "quorum {quorum} must fail");
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_effort() {
+        let toml = r#"
+[profiles.bad]
+members = ["kimi:kimi-code/k3@ludicrous"]
+"#;
+        assert!(Config::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_strategy_before_any_run() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.bad]
+strategy = "judeg"
+members = ["codex:default@xhigh"]
+"#,
+        );
+        let error = config.unwrap_err().to_string();
+        assert!(error.contains("Unknown strategy: judeg"), "got: {error}");
+    }
+
+    #[test]
+    fn discovery_precedence() {
+        let dir = env::temp_dir().join(format!("caucus-test-{}", std::process::id()));
+        let cwd = dir.join("cwd");
+        let xdg = dir.join("xdg");
+        let home = dir.join("home");
+        for d in [&cwd, &xdg, &home] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        let body = "[profiles.a]\nquorum = 1\nmembers = [\"codex:default@xhigh\"]\n";
+        std::fs::write(cwd.join("caucus.toml"), body).unwrap();
+        std::fs::create_dir_all(xdg.join("caucus")).unwrap();
+        std::fs::write(xdg.join("caucus").join("config.toml"), body).unwrap();
+        std::fs::create_dir_all(home.join(".config").join("caucus")).unwrap();
+        std::fs::write(home.join(".config").join("caucus").join("config.toml"), body).unwrap();
+
+        // cwd wins over xdg and home.
+        let (path, _) = Config::discover_in(None, &cwd, Some(&xdg), Some(&home)).unwrap().unwrap();
+        assert_eq!(path, cwd.join("caucus.toml"));
+
+        // xdg wins over home when cwd has no file.
+        std::fs::remove_file(cwd.join("caucus.toml")).unwrap();
+        let (path, _) = Config::discover_in(None, &cwd, Some(&xdg), Some(&home)).unwrap().unwrap();
+        assert_eq!(path, xdg.join("caucus").join("config.toml"));
+
+        // explicit path wins over everything.
+        let explicit = dir.join("explicit.toml");
+        std::fs::write(&explicit, body).unwrap();
+        let (path, _) =
+            Config::discover_in(Some(&explicit), &cwd, Some(&xdg), Some(&home)).unwrap().unwrap();
+        assert_eq!(path, explicit);
+
+        // nothing found -> None.
+        let empty = dir.join("empty");
+        std::fs::create_dir_all(&empty).unwrap();
+        assert!(Config::discover_in(None, &empty, Some(&empty), Some(&empty)).unwrap().is_none());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn legacy_schema_migrates_with_warnings() {
+        let toml = r#"
+[profiles.deep]
+models = [
+  "claude:claude-opus-4-6@xhigh",
+  "claude:claude-fable-5@xhigh",
+  "codex@xhigh",
+  "glm:zai-coding-plan/glm-5.2@xhigh",
+  "kimi:kimi-code/k3@high",
+]
+judge = "claude:claude-fable-5@xhigh"
+quorum = 4
+timeout_seconds = 240
+deadline_seconds = 900
+"#;
+        let config = Config::from_toml_str(toml).unwrap();
+        let council = config.resolve_profile(Some("deep")).unwrap();
+
+        // `models` -> `members`; pin-less and aliased entries are migrated.
+        let rendered: Vec<String> = council.members.iter().map(|m| m.to_string()).collect();
+        assert_eq!(
+            rendered,
+            vec![
+                "claude:claude-opus-4-6@xhigh",
+                "claude:claude-fable-5@xhigh",
+                "codex:default@xhigh",
+                "opencode:zai-coding-plan/glm-5.2@xhigh",
+                "kimi:kimi-code/k3@high",
+            ]
+        );
+        // Judge meaning is preserved, not discarded.
+        assert_eq!(
+            council.judge.as_ref().map(ToString::to_string).as_deref(),
+            Some("claude:claude-fable-5@xhigh")
+        );
+        // Both legacy meanings are preserved independently.
+        assert_eq!(council.request_timeout_secs, Some(240));
+        assert_eq!(council.deadline_secs, Some(900));
+        assert_eq!(council.quorum, 4);
+        assert_eq!(council.strategy, "judge");
+
+        let warnings = config.warnings.join("\n");
+        assert!(warnings.contains("`models` was renamed to `members`"), "got: {warnings}");
+        assert!(warnings.contains("alias `glm` resolves to `opencode`"), "got: {warnings}");
+        assert!(warnings.contains("`codex@xhigh` has no model pin"), "got: {warnings}");
+        assert!(
+            warnings.contains("`timeout_seconds` now maps to `request_timeout_secs`"),
+            "got: {warnings}"
+        );
+        assert!(
+            warnings.contains("`deadline_seconds` now maps to `deadline_secs`"),
+            "got: {warnings}"
+        );
+    }
+
+    #[test]
+    fn legacy_deadline_seconds_maps_to_whole_run_deadline() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.solo]
+members = ["codex:default@xhigh"]
+deadline_seconds = 900
+"#,
+        )
+        .unwrap();
+        let council = config.resolve_profile(Some("solo")).unwrap();
+        assert_eq!(council.deadline_secs, Some(900));
+        assert_eq!(council.request_timeout_secs, None);
+        assert_eq!(config.warnings.len(), 1);
+        assert!(config.warnings[0].contains("`deadline_seconds` now maps to `deadline_secs`"));
+    }
+
+    #[test]
+    fn modern_keys_take_precedence_over_legacy_duplicates() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.mixed]
+models = ["kimi:kimi-code/k3@high"]
+members = ["codex:default@xhigh"]
+timeout_seconds = 60
+request_timeout_secs = 30
+deadline_secs = 120
+"#,
+        )
+        .unwrap();
+        let council = config.resolve_profile(Some("mixed")).unwrap();
+        assert_eq!(council.members.len(), 1);
+        assert_eq!(council.members[0].utility, crate::adapters::Utility::Codex);
+        assert_eq!(council.deadline_secs, Some(120));
+        assert_eq!(council.request_timeout_secs, Some(30));
+        let warnings = config.warnings.join("\n");
+        assert!(warnings.contains("ignoring the legacy `models` list"), "got: {warnings}");
+        assert!(warnings.contains("`timeout_seconds` ignored"), "got: {warnings}");
+    }
+
+    #[test]
+    fn designated_judge_is_validated_like_a_member() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.j]
+members = ["codex:default@xhigh", "kimi:kimi-code/k3@high"]
+judge = "claude:opus@max"
+"#,
+        )
+        .unwrap();
+        let council = config.resolve_profile(Some("j")).unwrap();
+        assert_eq!(
+            council.judge.as_ref().map(ToString::to_string).as_deref(),
+            Some("claude:opus@max")
+        );
+        assert!(config.warnings.is_empty());
+
+        let bad = Config::from_toml_str(
+            r#"
+[profiles.j]
+members = ["codex:default@xhigh"]
+judge = "kimi:kimi-code/k3@xhigh"
+"#,
+        );
+        assert!(bad.is_err(), "an unsupported judge effort must fail validation");
+    }
+
+    #[test]
+    fn modern_config_produces_no_warnings() {
+        let config = Config::from_toml_str(
+            r#"
+[profiles.min]
+members = ["codex:default@xhigh"]
+"#,
+        )
+        .unwrap();
+        assert!(config.warnings.is_empty());
+    }
+}

--- a/crates/caucus-core/src/error.rs
+++ b/crates/caucus-core/src/error.rs
@@ -1,0 +1,124 @@
+//! Normalized provider error classification.
+//!
+//! [`ProviderError`] pairs a machine-readable [`ErrorKind`] with a message so
+//! callers (fan-out reports, receipts, CLI warnings) can distinguish timeouts,
+//! auth failures, and parse errors without string matching.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Classification of a provider failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ErrorKind {
+    /// Request exceeded its wall-clock timeout.
+    Timeout,
+    /// Authentication or authorization failed (HTTP 401/403).
+    Auth,
+    /// Rate limited by the upstream API (HTTP 429).
+    RateLimited,
+    /// Connection failed or the upstream service is unavailable (5xx).
+    Unavailable,
+    /// The response could not be parsed into the expected shape.
+    Parse,
+    /// The capability is recognized but deliberately not supported by this build.
+    Unsupported,
+    /// Anything not covered above.
+    Other,
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Timeout => "timeout",
+            Self::Auth => "auth",
+            Self::RateLimited => "rate-limited",
+            Self::Unavailable => "unavailable",
+            Self::Parse => "parse",
+            Self::Unsupported => "unsupported",
+            Self::Other => "other",
+        };
+        f.write_str(s)
+    }
+}
+
+/// An error raised by a provider, carrying a normalized [`ErrorKind`].
+#[derive(Debug)]
+pub struct ProviderError {
+    kind: ErrorKind,
+    message: String,
+}
+
+impl ProviderError {
+    pub fn new(kind: ErrorKind, message: impl Into<String>) -> Self {
+        Self { kind, message: message.into() }
+    }
+
+    /// Construct a timeout error.
+    pub fn timeout(message: impl Into<String>) -> Self {
+        Self::new(ErrorKind::Timeout, message)
+    }
+
+    /// The normalized classification of this error.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Classify any error: returns the [`ErrorKind`] of a [`ProviderError`],
+    /// or [`ErrorKind::Other`] for anything else.
+    pub fn classify(err: &anyhow::Error) -> ErrorKind {
+        err.downcast_ref::<ProviderError>().map(|e| e.kind).unwrap_or(ErrorKind::Other)
+    }
+}
+
+impl fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ProviderError {}
+
+/// Classify a [`reqwest`] failure into a [`ProviderError`].
+pub fn from_reqwest(err: &reqwest::Error) -> ProviderError {
+    let kind = if err.is_timeout() {
+        ErrorKind::Timeout
+    } else if err.is_connect() {
+        ErrorKind::Unavailable
+    } else if let Some(status) = err.status() {
+        match status.as_u16() {
+            401 | 403 => ErrorKind::Auth,
+            429 => ErrorKind::RateLimited,
+            s if s >= 500 => ErrorKind::Unavailable,
+            _ => ErrorKind::Other,
+        }
+    } else {
+        ErrorKind::Other
+    };
+    ProviderError::new(kind, err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_preserves_provider_error_kind() {
+        let err: anyhow::Error = ProviderError::new(ErrorKind::Auth, "bad key").into();
+        assert_eq!(ProviderError::classify(&err), ErrorKind::Auth);
+    }
+
+    #[test]
+    fn classify_falls_back_to_other() {
+        let err = anyhow::anyhow!("boom");
+        assert_eq!(ProviderError::classify(&err), ErrorKind::Other);
+    }
+
+    #[test]
+    fn timeout_constructor_sets_kind() {
+        let err = ProviderError::timeout("too slow");
+        assert_eq!(err.kind(), ErrorKind::Timeout);
+        assert_eq!(err.to_string(), "too slow");
+    }
+}

--- a/crates/caucus-core/src/fanout.rs
+++ b/crates/caucus-core/src/fanout.rs
@@ -1,0 +1,150 @@
+//! Bounded concurrent fan-out.
+//!
+//! [`bounded_fanout`] runs named tasks with a hard concurrency bound and
+//! returns successes and failures without losing either, in input order.
+//! The provider-specific fan-out used by the engine lives in
+//! [`crate::provider::fanout`].
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+/// A normalized per-task failure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureRecord {
+    pub name: String,
+    pub error: String,
+}
+
+/// Aggregate outcome of a [`bounded_fanout`] run.
+#[derive(Debug, Clone)]
+pub struct FanoutBatch<T> {
+    /// Successful results, in input order.
+    pub successes: Vec<(String, T)>,
+    /// Failed tasks, in input order.
+    pub failures: Vec<FailureRecord>,
+}
+
+// Manual impl: `#[derive(Default)]` would require `T: Default`.
+impl<T> Default for FanoutBatch<T> {
+    fn default() -> Self {
+        Self { successes: Vec::new(), failures: Vec::new() }
+    }
+}
+
+impl<T> FanoutBatch<T> {
+    pub fn success_count(&self) -> usize {
+        self.successes.len()
+    }
+
+    pub fn quorum_met(&self, quorum: usize) -> bool {
+        self.successes.len() >= quorum
+    }
+}
+
+/// Run named tasks concurrently, bounded by `max_concurrency`.
+/// Results are returned in input order regardless of completion order.
+pub async fn bounded_fanout<T, F, Fut>(
+    tasks: Vec<(String, F)>,
+    max_concurrency: usize,
+) -> FanoutBatch<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = Result<T>> + Send + 'static,
+{
+    let semaphore = Arc::new(Semaphore::new(max_concurrency.max(1)));
+    let mut set: JoinSet<(usize, String, Result<T>)> = JoinSet::new();
+
+    for (index, (name, task)) in tasks.into_iter().enumerate() {
+        let permit = Arc::clone(&semaphore);
+        set.spawn(async move {
+            let _permit = permit.acquire_owned().await.expect("semaphore open");
+            (index, name, task().await)
+        });
+    }
+
+    let mut ordered: Vec<(usize, String, Result<T>)> = Vec::new();
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok(outcome) => ordered.push(outcome),
+            Err(err) => tracing::warn!("fan-out task failed to join: {err}"),
+        }
+    }
+    ordered.sort_by_key(|(index, _, _)| *index);
+
+    let mut batch = FanoutBatch::default();
+    for (_, name, result) in ordered {
+        match result {
+            Ok(value) => batch.successes.push((name, value)),
+            Err(err) => batch.failures.push(FailureRecord { name, error: format!("{err:#}") }),
+        }
+    }
+    batch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn bounded_fanout_collects_in_order() {
+        let tasks: Vec<(String, _)> = (0..4)
+            .map(|i| {
+                (format!("t{i}"), move || async move {
+                    tokio::time::sleep(Duration::from_millis((4 - i) * 10)).await;
+                    Ok(i)
+                })
+            })
+            .collect();
+        let batch = bounded_fanout(tasks, 2).await;
+        let names: Vec<&str> = batch.successes.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, ["t0", "t1", "t2", "t3"]);
+        assert!(batch.quorum_met(4));
+    }
+
+    #[tokio::test]
+    async fn bounded_fanout_keeps_failures() {
+        use std::future::Future;
+        use std::pin::Pin;
+
+        type BoxedTask =
+            Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = Result<i32>> + Send>> + Send>;
+        let tasks: Vec<(String, BoxedTask)> = vec![
+            ("ok".to_string(), Box::new(|| Box::pin(async { Ok(1) }))),
+            ("bad".to_string(), Box::new(|| Box::pin(async { Err(anyhow::anyhow!("nope")) }))),
+        ];
+        let batch = bounded_fanout(tasks, 2).await;
+        assert_eq!(batch.success_count(), 1);
+        assert_eq!(batch.failures.len(), 1);
+        assert_eq!(batch.failures[0].name, "bad");
+        assert!(batch.failures[0].error.contains("nope"));
+    }
+
+    #[tokio::test]
+    async fn bounded_fanout_bounds_concurrency() {
+        let current = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let tasks: Vec<(String, _)> = (0..6)
+            .map(|i| {
+                let current = Arc::clone(&current);
+                let peak = Arc::clone(&peak);
+                (format!("t{i}"), move || async move {
+                    let now = current.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    current.fetch_sub(1, Ordering::SeqCst);
+                    Ok(i)
+                })
+            })
+            .collect();
+        let batch = bounded_fanout(tasks, 2).await;
+        assert_eq!(batch.success_count(), 6);
+        assert!(peak.load(Ordering::SeqCst) <= 2);
+    }
+}

--- a/crates/caucus-core/src/lib.rs
+++ b/crates/caucus-core/src/lib.rs
@@ -22,16 +22,40 @@
 //! # }
 //! ```
 
+pub mod adapters;
+pub mod config;
+pub mod error;
+pub mod fanout;
 pub mod format;
 pub mod pipeline;
+pub mod process;
 pub mod provider;
 pub mod strategy;
 pub mod types;
 
 // Re-export primary types at the crate root for convenience.
+pub use adapters::{
+    AcpProvider, AdapterDescriptor, AdapterOverrides, CommandInvocation, CommandProvider,
+    CommandSpec, Discovered, Effort, KIMI_EFFORT_ENV, MemberSpec, PromptDelivery, Readiness,
+    Stability, Utility, build_invocation, build_invocation_with, descriptor, descriptors,
+    provider_for, provider_for_with, utility_ids, validate_effort,
+};
+pub use config::{Config, ConfigError, Council, Profile, builtin_profiles};
+pub use error::{ErrorKind, ProviderError, from_reqwest};
+pub use fanout::{FailureRecord, FanoutBatch, bounded_fanout};
 pub use pipeline::{Pipeline, VoteMethod, consensus, strategy_from_name};
-pub use provider::{HttpProvider, MockProvider, MultiProvider};
-pub use types::{Candidate, ConsensusResult, ConsensusStrategy, LlmProvider};
+pub use process::{
+    ProcessLimits, ProcessOutput, ProcessSpec, SAFE_ENV_ALLOWLIST, SAFE_ENV_PREFIXES, find_on_path,
+    run_argv,
+};
+pub use provider::{
+    DEFAULT_REQUEST_TIMEOUT, FanoutConfig, FanoutFailure, FanoutReport, FanoutSuccess,
+    HttpProvider, MockProvider, MultiProvider,
+};
+pub use types::{
+    Candidate, CompleteOutcome, ConsensusResult, ConsensusStrategy, LlmProvider, ProviderOptions,
+    ResponseMeta, Transport,
+};
 
 pub use format::OutputFormat;
 pub use strategy::{

--- a/crates/caucus-core/src/process.rs
+++ b/crates/caucus-core/src/process.rs
@@ -1,0 +1,652 @@
+//! Safe subprocess runtime for CLI-backed providers.
+//!
+//! All command execution goes through [`run_argv`]: an explicit argv vector
+//! (never a shell), controlled stdin/env/cwd, `kill_on_drop`, a wall-clock
+//! timeout, and capped stdout/stderr capture. Errors are normalized into
+//! [`ProviderError`] so callers can classify failures without inspecting
+//! OS-specific error text.
+//!
+//! Children start from a scrubbed environment (`env_clear`) with only a
+//! documented safe baseline restored (see [`SAFE_ENV_ALLOWLIST`]). A caller
+//! may additionally inherit exact, adapter-specific variables via
+//! [`ProcessSpec::inherit_env`] or provide explicit overrides via
+//! [`ProcessSpec::env`]. This keeps ambient secrets out by default while
+//! allowing a known CLI adapter to receive only the auth/config/proxy state it
+//! actually needs.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ErrorKind, ProviderError};
+
+/// A command to run: program plus explicit arguments. Never a shell string.
+#[derive(Debug, Clone)]
+pub struct ProcessSpec {
+    /// Executable name or path (looked up on PATH if not absolute).
+    pub program: String,
+    /// Arguments, in order. Each is passed verbatim — no shell expansion.
+    pub args: Vec<String>,
+    /// Bytes written to the child's stdin (stdin is closed immediately after).
+    pub stdin: Option<String>,
+    /// Explicit environment overrides applied after the scrubbed-allowlist
+    /// environment is built (see [`run_argv`]). Values are never logged.
+    pub env: Vec<(String, String)>,
+    /// Exact parent environment names to inherit in addition to the safe
+    /// baseline. Intended for adapter-specific auth/config/proxy variables.
+    pub inherit_env: Vec<String>,
+    /// Working directory for the child (defaults to the current directory).
+    pub cwd: Option<PathBuf>,
+}
+
+impl ProcessSpec {
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            stdin: None,
+            env: Vec::new(),
+            inherit_env: Vec::new(),
+            cwd: None,
+        }
+    }
+
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args = args.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn stdin(mut self, input: impl Into<String>) -> Self {
+        self.stdin = Some(input.into());
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Inherit one exact variable from the parent environment if it exists.
+    pub fn inherit_env(mut self, key: impl Into<String>) -> Self {
+        self.inherit_env.push(key.into());
+        self
+    }
+
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+    /// The full argv vector (program first), for logging and tests.
+    pub fn argv(&self) -> Vec<String> {
+        std::iter::once(self.program.clone()).chain(self.args.iter().cloned()).collect()
+    }
+}
+
+/// Limits applied to a child process.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ProcessLimits {
+    /// Wall-clock timeout; the child is killed when it expires.
+    pub timeout: Duration,
+    /// Maximum stdout bytes retained; excess is discarded and flagged.
+    pub max_stdout_bytes: usize,
+    /// Maximum stderr bytes retained; excess is discarded and flagged.
+    pub max_stderr_bytes: usize,
+}
+
+impl Default for ProcessLimits {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(300),
+            max_stdout_bytes: 1024 * 1024,
+            max_stderr_bytes: 256 * 1024,
+        }
+    }
+}
+
+impl ProcessLimits {
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+/// Captured result of a completed child process.
+#[derive(Debug, Clone)]
+pub struct ProcessOutput {
+    pub stdout: String,
+    pub stderr: String,
+    /// Exit code; `None` if the process was terminated by a signal.
+    pub exit_code: Option<i32>,
+    /// Wall-clock time from spawn to exit.
+    pub latency_ms: u64,
+    /// True when stdout and/or stderr exceeded the configured cap.
+    pub truncated: bool,
+}
+
+impl ProcessOutput {
+    pub fn success(&self) -> bool {
+        self.exit_code == Some(0)
+    }
+}
+
+/// Exact-name environment variables restored after `env_clear`.
+///
+/// Everything here is non-secret and needed for a CLI to behave sanely:
+/// program lookup, basic identity, locale/terminal settings, temp dirs, and
+/// the minimal Windows system variables. Anything not listed (or not matching
+/// [`SAFE_ENV_PREFIXES`]) is scrubbed from the child environment unless the
+/// caller explicitly inherits it with [`ProcessSpec::inherit_env`] or
+/// supplies it via [`ProcessSpec::env`].
+pub const SAFE_ENV_ALLOWLIST: &[&str] = &[
+    // Program lookup and basic session identity.
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    // Terminal and locale behaviour.
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    // Temporary directories.
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    // Minimal Windows system variables (no-ops elsewhere).
+    "SystemRoot",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+];
+
+/// Environment variable name prefixes restored after `env_clear`.
+///
+/// `XDG_*` covers the freedesktop base-directory spec (config/data/cache/
+/// runtime dirs and their search paths); none of these hold credentials.
+pub const SAFE_ENV_PREFIXES: &[&str] = &["XDG_"];
+
+/// Run `spec` to completion under `limits`.
+///
+/// The child is spawned directly from the argv vector (never via a shell)
+/// with `kill_on_drop`. Its environment is scrubbed with `env_clear`, then
+/// only [`SAFE_ENV_ALLOWLIST`] / [`SAFE_ENV_PREFIXES`] entries inherited from
+/// this process are restored, then exact `spec.inherit_env` names, and finally
+/// `spec.env` overrides. Stdin is written and closed, and stdout/stderr are
+/// drained concurrently (capped) by reader tasks that are always awaited
+/// before this function returns. A non-zero exit is an error carrying the
+/// tail of stderr; a missing executable maps to [`ErrorKind::Unavailable`];
+/// a timeout explicitly kills and reaps the child and maps to
+/// [`ErrorKind::Timeout`].
+pub async fn run_argv(spec: &ProcessSpec, limits: &ProcessLimits) -> Result<ProcessOutput> {
+    let started = Instant::now();
+    let mut cmd = tokio::process::Command::new(&spec.program);
+    cmd.args(&spec.args)
+        .kill_on_drop(true)
+        .stdin(if spec.stdin.is_some() {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        })
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    #[cfg(unix)]
+    cmd.process_group(0);
+    // Scrub the inherited environment, restore only the safe non-secret
+    // allowlist, then apply explicit caller overrides.
+    cmd.env_clear();
+    for (key, value) in std::env::vars_os() {
+        let listed = key.to_str().is_some_and(|k| {
+            SAFE_ENV_ALLOWLIST.contains(&k)
+                || SAFE_ENV_PREFIXES.iter().any(|p| k.starts_with(p))
+                || spec.inherit_env.iter().any(|name| name == k)
+        });
+        if listed {
+            cmd.env(key, value);
+        }
+    }
+    for (key, value) in &spec.env {
+        cmd.env(key, value);
+    }
+    if let Some(cwd) = &spec.cwd {
+        cmd.current_dir(cwd);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        let kind = if e.kind() == std::io::ErrorKind::NotFound {
+            ErrorKind::Unavailable
+        } else {
+            ErrorKind::Other
+        };
+        ProviderError::new(kind, format!("failed to spawn `{}`: {e}", spec.program))
+    })?;
+    let process_id = child.id();
+    #[cfg(unix)]
+    let mut process_group = ProcessGroupGuard::new(process_id);
+
+    if let Some(input) = &spec.stdin {
+        let mut stdin = child.stdin.take().expect("stdin piped");
+        let input = input.clone();
+        // Write on a task so a large prompt can't deadlock against a child
+        // that stops reading; ignore EPIPE (child exited early).
+        tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let _ = stdin.write_all(input.as_bytes()).await;
+            let _ = stdin.shutdown().await;
+        });
+    }
+
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+    let out_limit = limits.max_stdout_bytes;
+    let err_limit = limits.max_stderr_bytes;
+    let stdout_capture = Arc::new(Mutex::new(Capture::default()));
+    let stderr_capture = Arc::new(Mutex::new(Capture::default()));
+    let out_shared = Arc::clone(&stdout_capture);
+    let err_shared = Arc::clone(&stderr_capture);
+    let mut out_task =
+        tokio::spawn(async move { read_capped(&mut stdout, out_limit, out_shared).await });
+    let mut err_task =
+        tokio::spawn(async move { read_capped(&mut stderr, err_limit, err_shared).await });
+
+    let status = match tokio::time::timeout(limits.timeout, child.wait()).await {
+        Ok(status) => status,
+        Err(_) => {
+            terminate_process_tree(&mut child, process_id).await;
+            #[cfg(unix)]
+            process_group.disarm();
+            let _ = tokio::time::timeout(PIPE_DRAIN_TIMEOUT, async {
+                let _ = tokio::join!(&mut out_task, &mut err_task);
+            })
+            .await;
+            out_task.abort();
+            err_task.abort();
+            return Err(ProviderError::timeout(format!(
+                "`{}` exceeded {}s timeout",
+                spec.program,
+                limits.timeout.as_secs()
+            ))
+            .into());
+        }
+    };
+    let status =
+        status.map_err(|e| ProviderError::new(ErrorKind::Other, format!("wait failed: {e}")))?;
+    let mut out = None;
+    let mut err = None;
+    let mut pipes_held_open = false;
+    if tokio::time::timeout(
+        PIPE_DRAIN_TIMEOUT,
+        drain_readers(&mut out_task, &mut err_task, &mut out, &mut err),
+    )
+    .await
+    .is_err()
+    {
+        pipes_held_open = true;
+        // The direct child exited but a descendant kept an inherited output
+        // pipe open. Kill that descendant group, then finish only the reader
+        // tasks that did not complete during the first drain attempt.
+        #[cfg(unix)]
+        process_group.kill();
+        if tokio::time::timeout(
+            PIPE_DRAIN_TIMEOUT,
+            drain_readers(&mut out_task, &mut err_task, &mut out, &mut err),
+        )
+        .await
+        .is_err()
+        {
+            // A process outside the child's group can still hold a leaked
+            // pipe (notably the macOS pipe()/fcntl() close-on-exec race).
+            // Preserve bytes captured so far and flag truncation instead of
+            // turning a successful direct child into a false timeout.
+            if out.is_none() {
+                out_task.abort();
+                let _ = (&mut out_task).await;
+            }
+            if err.is_none() {
+                err_task.abort();
+                let _ = (&mut err_task).await;
+            }
+        }
+    }
+    #[cfg(unix)]
+    process_group.disarm();
+
+    validate_reader_result(out, pipes_held_open, "stdout")?;
+    validate_reader_result(err, pipes_held_open, "stderr")?;
+    let (stdout, out_truncated) = snapshot_capture(&stdout_capture);
+    let (stderr, err_truncated) = snapshot_capture(&stderr_capture);
+
+    let output = ProcessOutput {
+        stdout,
+        stderr,
+        exit_code: status.code(),
+        latency_ms: started.elapsed().as_millis() as u64,
+        truncated: out_truncated || err_truncated || pipes_held_open,
+    };
+
+    if !output.success() {
+        let detail = output.stderr.lines().last().unwrap_or("").trim();
+        return Err(ProviderError::new(
+            ErrorKind::Other,
+            format!(
+                "`{}` exited with code {:?}{}",
+                spec.program,
+                output.exit_code,
+                if detail.is_empty() { String::new() } else { format!(": {detail}") }
+            ),
+        )
+        .into());
+    }
+
+    Ok(output)
+}
+
+/// Maximum time allowed for descendants to close inherited output pipes
+/// after their direct child exits or is killed.
+#[cfg(not(test))]
+const PIPE_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const PIPE_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
+
+type ReaderResult = std::result::Result<std::io::Result<()>, tokio::task::JoinError>;
+
+async fn drain_readers(
+    out_task: &mut tokio::task::JoinHandle<std::io::Result<()>>,
+    err_task: &mut tokio::task::JoinHandle<std::io::Result<()>>,
+    out: &mut Option<ReaderResult>,
+    err: &mut Option<ReaderResult>,
+) {
+    while out.is_none() || err.is_none() {
+        tokio::select! {
+            result = &mut *out_task, if out.is_none() => *out = Some(result),
+            result = &mut *err_task, if err.is_none() => *err = Some(result),
+        }
+    }
+}
+
+fn validate_reader_result(
+    result: Option<ReaderResult>,
+    allowed_incomplete: bool,
+    stream: &str,
+) -> Result<()> {
+    match result {
+        Some(joined) => joined
+            .map_err(|error| {
+                ProviderError::new(ErrorKind::Other, format!("{stream} task failed: {error}"))
+            })?
+            .map_err(|error| {
+                ProviderError::new(ErrorKind::Other, format!("{stream} read failed: {error}"))
+            }),
+        None if allowed_incomplete => Ok(()),
+        None => {
+            Err(ProviderError::new(ErrorKind::Other, format!("{stream} reader did not complete")))
+        }
+    }
+    .map_err(Into::into)
+}
+
+async fn terminate_process_tree(child: &mut tokio::process::Child, process_id: Option<u32>) {
+    #[cfg(unix)]
+    if let Some(process_id) = process_id {
+        // Every command is placed in its own process group before spawn.
+        unsafe {
+            libc::kill(-(process_id as i32), libc::SIGKILL);
+        }
+    }
+    let _ = child.kill().await;
+    let _ = tokio::time::timeout(PIPE_DRAIN_TIMEOUT, child.wait()).await;
+}
+
+/// Cancellation safety for Unix: dropping `run_argv` (for example when an
+/// outer whole-run deadline expires) terminates the command's process group,
+/// including descendants. Disarmed immediately after a normal child exit.
+#[cfg(unix)]
+struct ProcessGroupGuard {
+    pgid: Option<i32>,
+}
+
+#[cfg(unix)]
+impl ProcessGroupGuard {
+    fn new(process_id: Option<u32>) -> Self {
+        Self { pgid: process_id.map(|id| id as i32) }
+    }
+
+    fn disarm(&mut self) {
+        self.pgid = None;
+    }
+
+    fn kill(&mut self) {
+        if let Some(pgid) = self.pgid.take() {
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+#[derive(Default)]
+struct Capture {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+fn snapshot_capture(capture: &Arc<Mutex<Capture>>) -> (String, bool) {
+    let capture = capture.lock().expect("capture mutex poisoned");
+    (String::from_utf8_lossy(&capture.bytes).into_owned(), capture.truncated)
+}
+
+/// Read to EOF, keeping at most `limit` bytes in shared capture state. The
+/// shared buffer lets the caller preserve bytes if a leaked pipe forces the
+/// reader task to be aborted after the direct child has already exited.
+async fn read_capped<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut R,
+    limit: usize,
+    capture: Arc<Mutex<Capture>>,
+) -> std::io::Result<()> {
+    use tokio::io::AsyncReadExt;
+    let mut chunk = [0u8; 8192];
+    loop {
+        let n = reader.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        let mut state = capture.lock().expect("capture mutex poisoned");
+        let room = limit.saturating_sub(state.bytes.len());
+        if room > 0 {
+            state.bytes.extend_from_slice(&chunk[..n.min(room)]);
+        }
+        if n > room {
+            state.truncated = true;
+        }
+    }
+    Ok(())
+}
+
+/// Locate an executable on PATH without invoking a shell. Returns the first
+/// matching absolute path, or `None` when the binary is not found.
+pub fn find_on_path(program: &str) -> Option<PathBuf> {
+    let candidate = PathBuf::from(program);
+    if candidate.is_absolute() {
+        return candidate.exists().then_some(candidate);
+    }
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(program);
+        if candidate.is_file() && is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata().map(|m| m.permissions().mode() & 0o111 != 0).unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &std::path::Path) -> bool {
+    path.exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limits() -> ProcessLimits {
+        ProcessLimits::default().with_timeout(Duration::from_secs(10))
+    }
+
+    #[tokio::test]
+    async fn run_argv_captures_stdout() {
+        let spec = ProcessSpec::new("/bin/echo").arg("hello");
+        let out = run_argv(&spec, &limits()).await.unwrap();
+        assert!(out.success());
+        assert_eq!(out.stdout.trim(), "hello");
+        assert!(!out.truncated);
+    }
+
+    #[tokio::test]
+    async fn run_argv_writes_stdin() {
+        let spec = ProcessSpec::new("/bin/cat").stdin("piped in");
+        let out = run_argv(&spec, &limits()).await.unwrap();
+        assert_eq!(out.stdout, "piped in");
+    }
+
+    #[tokio::test]
+    async fn run_argv_nonzero_exit_is_error_with_stderr() {
+        let spec = ProcessSpec::new("/bin/sh").args(["-c", "echo boom >&2; exit 3"]);
+        let err = run_argv(&spec, &limits()).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains('3') && msg.contains("boom"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_argv_missing_binary_is_unavailable() {
+        let spec = ProcessSpec::new("definitely-not-a-real-binary-xyz");
+        let err = run_argv(&spec, &limits()).await.unwrap_err();
+        assert_eq!(ProviderError::classify(&err), ErrorKind::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn run_argv_timeout_is_classified() {
+        let spec = ProcessSpec::new("/bin/sleep").arg("30");
+        let tight = limits().with_timeout(Duration::from_millis(50));
+        let err = run_argv(&spec, &tight).await.unwrap_err();
+        assert_eq!(ProviderError::classify(&err), ErrorKind::Timeout);
+    }
+
+    #[tokio::test]
+    async fn run_argv_caps_output_and_flags_truncation() {
+        let spec = ProcessSpec::new("/bin/cat").stdin("x".repeat(10_000));
+        let tight = ProcessLimits { max_stdout_bytes: 100, ..limits() };
+        let out = run_argv(&spec, &tight).await.unwrap();
+        assert_eq!(out.stdout.len(), 100);
+        assert!(out.truncated);
+    }
+
+    #[tokio::test]
+    async fn run_argv_applies_env_overrides() {
+        // Explicit spec.env overrides reach the child even for names that are
+        // not on the inherited allowlist.
+        let spec = ProcessSpec::new("/usr/bin/env").env("CAUCUS_TEST_VAR", "override-works");
+        let out = run_argv(&spec, &limits()).await.unwrap();
+        assert!(out.stdout.lines().any(|l| l == "CAUCUS_TEST_VAR=override-works"));
+    }
+
+    #[tokio::test]
+    async fn run_argv_inherits_only_explicit_adapter_variable() {
+        let inherited = std::env::var("CARGO_MANIFEST_DIR").expect("cargo sets manifest dir");
+        let spec = ProcessSpec::new("/usr/bin/env").inherit_env("CARGO_MANIFEST_DIR");
+        let out = run_argv(&spec, &limits()).await.unwrap();
+        assert!(out.stdout.lines().any(|line| line == format!("CARGO_MANIFEST_DIR={inherited}")));
+        assert!(!out.stdout.lines().any(|line| line.starts_with("CARGO_PKG_NAME=")));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timeout_kills_descendant_process_group() {
+        let marker = std::env::temp_dir().join(format!(
+            "caucus-descendant-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let script = format!("sleep 30 & echo $! > '{}'; wait", marker.display());
+        let spec = ProcessSpec::new("/bin/sh").args(["-c", &script]);
+        let err =
+            run_argv(&spec, &ProcessLimits::default().with_timeout(Duration::from_millis(250)))
+                .await
+                .unwrap_err();
+        assert_eq!(ProviderError::classify(&err), ErrorKind::Timeout);
+        let pid: i32 = std::fs::read_to_string(&marker).unwrap().trim().parse().unwrap();
+        let _ = std::fs::remove_file(&marker);
+
+        let mut gone = false;
+        for _ in 0..20 {
+            let alive = unsafe { libc::kill(pid, 0) } == 0;
+            if !alive {
+                gone = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(gone, "descendant process {pid} survived timeout cleanup");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn successful_child_keeps_output_when_descendant_holds_pipe_open() {
+        let spec = ProcessSpec::new("/bin/sh").args(["-c", "sleep 30 & echo complete"]);
+        let output = run_argv(&spec, &limits()).await.unwrap();
+        assert_eq!(output.stdout.trim(), "complete");
+        assert!(output.success());
+        assert!(output.truncated, "forced pipe cleanup must be visible to callers");
+    }
+
+    #[tokio::test]
+    async fn run_argv_scrubs_non_allowlisted_env() {
+        assert!(std::env::var_os("CARGO_MANIFEST_DIR").is_some());
+        let spec = ProcessSpec::new("/usr/bin/env");
+        let out = run_argv(&spec, &limits()).await.unwrap();
+        assert!(
+            !out.stdout.lines().any(|l| l.starts_with("CARGO_MANIFEST_DIR=")),
+            "non-allowlisted variable leaked into child: {}",
+            out.stdout
+        );
+    }
+
+    #[tokio::test]
+    async fn run_argv_restores_allowlisted_env() {
+        // Allowlisted variables (e.g. PATH) survive env_clear.
+        let spec = ProcessSpec::new("/usr/bin/env");
+        let out = run_argv(&spec, &limits()).await.unwrap();
+        assert!(out.stdout.lines().any(|l| l.starts_with("PATH=")), "got: {}", out.stdout);
+    }
+
+    #[test]
+    fn argv_is_program_first() {
+        let spec = ProcessSpec::new("prog").args(["a", "b"]);
+        assert_eq!(spec.argv(), vec!["prog", "a", "b"]);
+    }
+}

--- a/crates/caucus-core/src/provider.rs
+++ b/crates/caucus-core/src/provider.rs
@@ -1,7 +1,14 @@
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::types::LlmProvider;
+use crate::error::{ErrorKind, ProviderError, from_reqwest};
+use crate::types::{LlmProvider, Transport};
+
+/// Default per-request timeout for HTTP providers and provider fan-out.
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// A mock LLM provider for testing. Returns canned responses.
 pub struct MockProvider {
@@ -23,6 +30,9 @@ impl MockProvider {
 #[async_trait]
 impl LlmProvider for MockProvider {
     async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+        if self.responses.is_empty() {
+            anyhow::bail!("mock provider has no configured responses");
+        }
         let idx =
             self.index.fetch_add(1, std::sync::atomic::Ordering::SeqCst) % self.responses.len();
         Ok(self.responses[idx].clone())
@@ -35,6 +45,8 @@ pub struct HttpProvider {
     base_url: String,
     api_key: String,
     model: String,
+    timeout: Duration,
+    transport: Transport,
 }
 
 impl HttpProvider {
@@ -48,6 +60,8 @@ impl HttpProvider {
             base_url: base_url.into(),
             api_key: api_key.into(),
             model: model.into(),
+            timeout: DEFAULT_REQUEST_TIMEOUT,
+            transport: Transport::Api,
         }
     }
 
@@ -70,6 +84,52 @@ impl HttpProvider {
     pub fn xai(api_key: impl Into<String>, model: impl Into<String>) -> Self {
         Self::new("https://api.x.ai/v1", api_key, model)
     }
+
+    /// Create a provider for a local Ollama server (no API key required).
+    pub fn ollama(model: impl Into<String>) -> Self {
+        Self::local("http://localhost:11434/v1", model)
+    }
+
+    /// Create a provider for a local LM Studio server (no API key required).
+    pub fn lmstudio(model: impl Into<String>) -> Self {
+        Self::local("http://localhost:1234/v1", model)
+    }
+
+    /// Create a provider for a local OpenAI-compatible server (no API key).
+    pub fn local(base_url: impl Into<String>, model: impl Into<String>) -> Self {
+        let mut provider = Self::new(base_url, "", model);
+        provider.transport = Transport::LocalServer;
+        provider
+    }
+
+    /// Override the per-request timeout (default 120s).
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// The model this provider is bound to.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Send a request with the configured timeout and normalize failures.
+    async fn send(&self, req: reqwest::RequestBuilder) -> Result<serde_json::Value> {
+        let attempt = async {
+            let resp = req.send().await.map_err(|error| from_reqwest(&error))?;
+            let resp = resp.error_for_status().map_err(|error| from_reqwest(&error))?;
+            resp.json::<serde_json::Value>()
+                .await
+                .map_err(|error| ProviderError::new(ErrorKind::Parse, error.to_string()).into())
+        };
+        match tokio::time::timeout(self.timeout, attempt).await {
+            Ok(result) => result,
+            Err(_) => {
+                Err(ProviderError::timeout(format!("exceeded {}s timeout", self.timeout.as_secs()))
+                    .into())
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -82,6 +142,14 @@ impl LlmProvider for HttpProvider {
             return self.complete_gemini(prompt, system).await;
         }
         self.complete_openai(prompt, system).await
+    }
+
+    fn transport(&self) -> Transport {
+        self.transport
+    }
+
+    fn options(&self) -> crate::types::ProviderOptions {
+        crate::types::ProviderOptions { timeout: self.timeout, ..Default::default() }
     }
 }
 
@@ -98,22 +166,15 @@ impl HttpProvider {
             "messages": messages,
         });
 
-        let resp = self
-            .client
-            .post(format!("{}/chat/completions", self.base_url))
-            .bearer_auth(&self.api_key)
-            .json(&body)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<serde_json::Value>()
-            .await?;
+        let mut req = self.client.post(format!("{}/chat/completions", self.base_url)).json(&body);
+        if !self.api_key.is_empty() {
+            req = req.bearer_auth(&self.api_key);
+        }
+        let resp = self.send(req).await?;
 
-        let content = resp["choices"][0]["message"]["content"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Unexpected OpenAI response format"))?;
-
-        Ok(content.to_string())
+        resp["choices"][0]["message"]["content"].as_str().map(str::to_string).ok_or_else(|| {
+            ProviderError::new(ErrorKind::Parse, "Unexpected OpenAI response format").into()
+        })
     }
 
     async fn complete_anthropic(&self, prompt: &str, system: Option<&str>) -> Result<String> {
@@ -126,23 +187,17 @@ impl HttpProvider {
             body["system"] = serde_json::json!(sys);
         }
 
-        let resp = self
+        let req = self
             .client
             .post(format!("{}/messages", self.base_url))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
-            .json(&body)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<serde_json::Value>()
-            .await?;
+            .json(&body);
+        let resp = self.send(req).await?;
 
-        let content = resp["content"][0]["text"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Unexpected Anthropic response format"))?;
-
-        Ok(content.to_string())
+        resp["content"][0]["text"].as_str().map(str::to_string).ok_or_else(|| {
+            ProviderError::new(ErrorKind::Parse, "Unexpected Anthropic response format").into()
+        })
     }
 
     async fn complete_gemini(&self, prompt: &str, system: Option<&str>) -> Result<String> {
@@ -167,28 +222,29 @@ impl HttpProvider {
             "contents": contents,
         });
 
-        let resp = self
+        let req = self
             .client
             .post(format!("{}/v1beta/models/{}:generateContent", self.base_url, self.model))
             .header("x-goog-api-key", &self.api_key)
-            .json(&body)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<serde_json::Value>()
-            .await?;
+            .json(&body);
+        let resp = self.send(req).await?;
 
-        let content = resp["candidates"][0]["content"]["parts"][0]["text"]
+        resp["candidates"][0]["content"]["parts"][0]["text"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Unexpected Gemini response format: {resp}"))?;
-
-        Ok(content.to_string())
+            .map(str::to_string)
+            .ok_or_else(|| {
+                ProviderError::new(
+                    ErrorKind::Parse,
+                    format!("Unexpected Gemini response format: {resp}"),
+                )
+                .into()
+            })
     }
 }
 
 /// A multi-model provider that dispatches to the right backend based on model name.
 pub struct MultiProvider {
-    providers: Vec<(String, Box<dyn LlmProvider>)>,
+    providers: Vec<(String, Arc<dyn LlmProvider>)>,
 }
 
 impl MultiProvider {
@@ -198,13 +254,32 @@ impl MultiProvider {
 
     /// Register a provider for a specific model name.
     pub fn add(mut self, model: impl Into<String>, provider: impl LlmProvider + 'static) -> Self {
-        self.providers.push((model.into(), Box::new(provider)));
+        self.providers.push((model.into(), Arc::new(provider)));
+        self
+    }
+
+    /// Register a pre-boxed provider (avoids double-boxing).
+    pub fn add_shared(mut self, model: impl Into<String>, provider: Arc<dyn LlmProvider>) -> Self {
+        self.providers.push((model.into(), provider));
         self
     }
 
     /// Get the provider for a given model name.
     pub fn get(&self, model: &str) -> Option<&dyn LlmProvider> {
-        self.providers.iter().find(|(name, _)| name == model).map(|(_, p)| p.as_ref())
+        self.providers
+            .iter()
+            .find(|(name, _)| name == model)
+            .map(|(_, p)| p.as_ref() as &dyn LlmProvider)
+    }
+
+    /// Get a shared handle to the provider for a given model name.
+    pub fn get_shared(&self, model: &str) -> Option<Arc<dyn LlmProvider>> {
+        self.providers.iter().find(|(name, _)| name == model).map(|(_, p)| Arc::clone(p))
+    }
+
+    /// Iterate over (model, provider) pairs in registration order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Arc<dyn LlmProvider>)> {
+        self.providers.iter().map(|(name, p)| (name.as_str(), p))
     }
 
     /// List all registered model names.
@@ -212,7 +287,21 @@ impl MultiProvider {
         self.providers.iter().map(|(name, _)| name.as_str()).collect()
     }
 
+    /// Number of registered providers.
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Whether any providers are registered.
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+
     /// Generate completions from all registered models for the given prompt.
+    ///
+    /// Kept for backwards compatibility (sequential, no timeout). New code
+    /// should prefer [`crate::fanout::bounded_fanout`] for bounded concurrency
+    /// and normalized partial-failure reporting.
     pub async fn generate_all(
         &self,
         prompt: &str,
@@ -230,5 +319,268 @@ impl MultiProvider {
 impl Default for MultiProvider {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bounded, timeout-aware fan-out
+// ---------------------------------------------------------------------------
+
+/// Tunables for [`fanout`].
+#[derive(Debug, Clone, Copy)]
+pub struct FanoutConfig {
+    /// Maximum number of in-flight requests.
+    pub max_concurrency: usize,
+    /// Hard timeout applied to each individual request.
+    pub timeout: Duration,
+    /// Minimum number of successful responses required.
+    pub quorum: usize,
+}
+
+impl Default for FanoutConfig {
+    fn default() -> Self {
+        Self { max_concurrency: 4, timeout: DEFAULT_REQUEST_TIMEOUT, quorum: 1 }
+    }
+}
+
+/// A successful fan-out response with provenance metadata.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FanoutSuccess {
+    pub model: String,
+    pub transport: Transport,
+    pub content: String,
+    pub latency_ms: u64,
+}
+
+/// A failed fan-out response with a normalized error classification.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FanoutFailure {
+    pub model: String,
+    pub transport: Transport,
+    pub kind: ErrorKind,
+    pub message: String,
+    pub latency_ms: u64,
+}
+
+/// The aggregated result of a [`fanout`]: partial failures are data, not
+/// exceptions. Use [`FanoutReport::quorum_met`] to decide whether the run
+/// produced enough responses to proceed.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FanoutReport {
+    pub successes: Vec<FanoutSuccess>,
+    pub failures: Vec<FanoutFailure>,
+    pub quorum: usize,
+}
+
+impl FanoutReport {
+    /// Whether at least `quorum` participants responded successfully.
+    pub fn quorum_met(&self) -> bool {
+        self.successes.len() >= self.quorum
+    }
+
+    /// A single-line warning per failure, for receipts and stderr output.
+    pub fn warnings(&self) -> Vec<String> {
+        self.failures
+            .iter()
+            .map(|f| format!("{} failed ({}): {}", f.model, f.kind, f.message))
+            .collect()
+    }
+}
+
+/// Query every provider in `multi` for the same prompt with bounded
+/// concurrency and a per-request timeout.
+///
+/// Partial failure is normal: every participant's outcome (success with
+/// latency/transport metadata, or a classified failure) is recorded in the
+/// returned report. The caller decides whether [`FanoutReport::quorum_met`]
+/// is sufficient to continue.
+pub async fn fanout(
+    multi: &MultiProvider,
+    prompt: &str,
+    system: Option<&str>,
+    config: FanoutConfig,
+) -> FanoutReport {
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(config.max_concurrency.max(1)));
+    let mut join_set = tokio::task::JoinSet::new();
+
+    for (model, provider) in multi.iter() {
+        let permit = Arc::clone(&semaphore);
+        let provider = Arc::clone(provider);
+        let model = model.to_string();
+        let prompt = prompt.to_string();
+        let system = system.map(str::to_string);
+        let timeout = config.timeout;
+
+        join_set.spawn(async move {
+            let _permit = permit.acquire().await.expect("semaphore not closed");
+            let started = std::time::Instant::now();
+            let transport = provider.transport();
+            let result =
+                tokio::time::timeout(timeout, provider.complete(&prompt, system.as_deref())).await;
+            let latency_ms = started.elapsed().as_millis() as u64;
+
+            match result {
+                Ok(Ok(content)) => Ok(FanoutSuccess { model, transport, content, latency_ms }),
+                Ok(Err(e)) => Err(FanoutFailure {
+                    model,
+                    transport,
+                    kind: ProviderError::classify(&e),
+                    message: e.to_string(),
+                    latency_ms,
+                }),
+                Err(_) => Err(FanoutFailure {
+                    model,
+                    transport,
+                    kind: ErrorKind::Timeout,
+                    message: format!("exceeded {}s timeout", timeout.as_secs()),
+                    latency_ms,
+                }),
+            }
+        });
+    }
+
+    let mut successes = Vec::new();
+    let mut failures = Vec::new();
+    while let Some(outcome) = join_set.join_next().await {
+        match outcome {
+            Ok(Ok(success)) => successes.push(success),
+            Ok(Err(failure)) => failures.push(failure),
+            Err(join_err) => failures.push(FanoutFailure {
+                model: "unknown".into(),
+                transport: Transport::Api,
+                kind: ErrorKind::Other,
+                message: format!("task panicked: {join_err}"),
+                latency_ms: 0,
+            }),
+        }
+    }
+
+    // Deterministic output: restore registration order.
+    let order: Vec<&str> = multi.models();
+    let rank = |model: &str| order.iter().position(|m| *m == model).unwrap_or(usize::MAX);
+    successes.sort_by_key(|s| rank(&s.model));
+    failures.sort_by_key(|f| rank(&f.model));
+
+    FanoutReport { successes, failures, quorum: config.quorum }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    struct FailProvider;
+
+    #[async_trait]
+    impl LlmProvider for FailProvider {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+            Err(ProviderError::new(ErrorKind::Unavailable, "always down").into())
+        }
+    }
+
+    struct SlowProvider;
+
+    #[async_trait]
+    impl LlmProvider for SlowProvider {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Ok("too late".into())
+        }
+    }
+
+    #[test]
+    fn local_constructors_use_local_server_transport() {
+        assert_eq!(HttpProvider::ollama("llama3.2").transport(), Transport::LocalServer);
+        assert_eq!(HttpProvider::lmstudio("qwen").transport(), Transport::LocalServer);
+        assert_eq!(HttpProvider::openai("k", "gpt").transport(), Transport::Api);
+    }
+
+    #[tokio::test]
+    async fn empty_mock_provider_returns_error_instead_of_panicking() {
+        let error = MockProvider::new(vec![]).complete("q", None).await.unwrap_err();
+        assert!(error.to_string().contains("no configured responses"));
+    }
+
+    #[tokio::test]
+    async fn http_timeout_covers_a_stalled_response_body() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1024\r\nConnection: close\r\n\r\n{",
+                )
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let provider = HttpProvider::local(format!("http://{address}"), "test-model")
+            .with_timeout(Duration::from_millis(75));
+        let error = provider.complete("hello", None).await.unwrap_err();
+        assert_eq!(ProviderError::classify(&error), ErrorKind::Timeout);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn fanout_collects_successes_and_failures() {
+        let multi = MultiProvider::new()
+            .add("good", MockProvider::fixed("answer"))
+            .add("bad", FailProvider);
+
+        let report =
+            fanout(&multi, "q", None, FanoutConfig { quorum: 1, ..Default::default() }).await;
+
+        assert_eq!(report.successes.len(), 1);
+        assert_eq!(report.successes[0].model, "good");
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].model, "bad");
+        assert_eq!(report.failures[0].kind, ErrorKind::Unavailable);
+        assert!(report.quorum_met());
+        assert_eq!(report.warnings().len(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fanout_enforces_timeout() {
+        let multi = MultiProvider::new().add("slow", SlowProvider);
+
+        let config =
+            FanoutConfig { timeout: Duration::from_millis(50), quorum: 1, ..Default::default() };
+        let report = fanout(&multi, "q", None, config).await;
+
+        assert!(report.successes.is_empty());
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].kind, ErrorKind::Timeout);
+        assert!(!report.quorum_met());
+    }
+
+    #[tokio::test]
+    async fn fanout_quorum_not_met_when_too_many_fail() {
+        let multi = MultiProvider::new()
+            .add("ok", MockProvider::fixed("yes"))
+            .add("bad1", FailProvider)
+            .add("bad2", FailProvider);
+
+        let report =
+            fanout(&multi, "q", None, FanoutConfig { quorum: 2, ..Default::default() }).await;
+
+        assert_eq!(report.successes.len(), 1);
+        assert!(!report.quorum_met());
+    }
+
+    #[tokio::test]
+    async fn fanout_preserves_registration_order() {
+        let multi = MultiProvider::new()
+            .add("c", MockProvider::fixed("3"))
+            .add("a", MockProvider::fixed("1"))
+            .add("b", MockProvider::fixed("2"));
+
+        let report = fanout(&multi, "q", None, FanoutConfig::default()).await;
+        let models: Vec<&str> = report.successes.iter().map(|s| s.model.as_str()).collect();
+        assert_eq!(models, ["c", "a", "b"]);
     }
 }

--- a/crates/caucus-core/src/strategy/debate.rs
+++ b/crates/caucus-core/src/strategy/debate.rs
@@ -2,12 +2,21 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::future::join_all;
 
+use crate::provider::MultiProvider;
 use crate::strategy::judge::{DEFAULT_JUDGE_SYSTEM, parse_judge_response};
 use crate::types::{Candidate, ConsensusResult, ConsensusStrategy, LlmProvider};
 
-/// Multi-round debate where candidates see each other's responses and refine their positions.
-/// Includes convergence detection to stop early when positions stabilize.
+/// Multi-round debate where each participant independently blind-critiques the
+/// current positions and revises its own. Includes convergence detection to
+/// stop early when positions stabilize.
+///
+/// "Blind" means positions are anonymized (no model names) and re-shuffled for
+/// every participant in every round, so no participant can tell which position
+/// is its own or anyone else's. "Independent" means each participant produces
+/// its own revised position via its own provider — there is no single
+/// broadcast rewrite shared by all.
 pub struct MultiRoundDebate {
     pub config: DebateConfig,
 }
@@ -32,44 +41,48 @@ impl Default for DebateConfig {
 }
 
 const DEFAULT_DEBATE_SYSTEM: &str = "\
-You are participating in a structured debate with other AI models. \
-You have been given a question and will see other participants' responses. \
-Carefully consider their arguments. If they make valid points, incorporate them. \
-If you disagree, explain why with clear reasoning. \
+You are participating in a structured deliberation with other AI models. \
+You will see anonymized positions; you do not know which participant wrote which \
+(one of them is your own earlier answer). \
+Critique each position on its merits. If a position makes valid points, incorporate them. \
+If it is wrong, explain why with clear reasoning. \
 Your goal is to arrive at the most accurate and well-reasoned answer.";
 
-const DEBATE_ROUND_PROMPT: &str = "\
+const BLIND_CRITIQUE_PROMPT: &str = "\
 Original question: {question}
 
-Here are the current positions from all participants:
+Below are the current positions in an ongoing deliberation. They are anonymized \
+and shuffled; you do not know which participant wrote which position — one of \
+them is your own earlier answer.
 
 {positions}
 
-This is round {round} of {max_rounds}. \
-Consider the strengths and weaknesses of each position, then produce a single, \
-standalone answer to the original question. Do NOT reference the other positions, \
-the debate process, or \"other participants\" — write as if you are the sole author \
-giving a definitive response.";
+This is round {round} of {max_rounds}.
+
+First, briefly identify the strongest weakness or gap in EACH position. \
+Then write your own revised, standalone answer to the original question, \
+incorporating whatever survives your critique. Do NOT reference the debate \
+process, position numbers, or \"other participants\" in the final answer — \
+write as if you are the sole author giving a definitive response.
+
+End your response with a line containing only \"FINAL ANSWER:\" followed by \
+your final answer.";
 
 const DEBATE_JUDGE_PROMPT: &str = "\
-Below is a synthesis produced by a multi-round debate, followed by the {count} original \
-candidate responses that entered the debate.
-
---- Debate Synthesis ---
-{synthesis}
+Below are the {count} final positions produced by an independent multi-round debate \
+on the same question.
 
 {candidates}
 
-Compare the synthesis to each original candidate. Determine how much the candidates \
-agree with the final synthesis overall, and identify any candidates whose position \
-significantly differs from the consensus.
+Evaluate how much the positions agree overall, synthesize the best possible answer \
+from them, and identify any positions that significantly diverge from the consensus.
 
 Respond in the following JSON format:
 {{
-  \"synthesis\": \"(copy the debate synthesis above verbatim)\",
+  \"synthesis\": \"Your synthesized best answer\",
   \"reasoning\": \"Brief explanation of agreement and disagreements\",
   \"agreement_score\": 0.0 to 1.0 representing overall agreement,
-  \"dissent_indices\": [zero-based indices of candidates that significantly disagreed]
+  \"dissent_indices\": [zero-based indices of positions that significantly disagreed]
 }}";
 
 impl MultiRoundDebate {
@@ -90,12 +103,326 @@ impl MultiRoundDebate {
         self.config.convergence_threshold = threshold;
         self
     }
+
+    /// Run the debate with an explicit provider per participant.
+    ///
+    /// `participant_llms[i]` refines `candidates[i]`'s position. `judge`
+    /// adjudicates the final positions.
+    pub async fn resolve_with_participants(
+        &self,
+        candidates: &[Candidate],
+        participant_llms: &[&dyn LlmProvider],
+        judge: &dyn LlmProvider,
+    ) -> Result<ConsensusResult> {
+        if candidates.is_empty() {
+            anyhow::bail!("No candidates provided");
+        }
+        if participant_llms.len() != candidates.len() {
+            anyhow::bail!(
+                "expected {} participant providers, got {}",
+                candidates.len(),
+                participant_llms.len()
+            );
+        }
+
+        // Extract the original question from metadata if available,
+        // otherwise use a generic prompt.
+        let question = candidates
+            .first()
+            .and_then(|c| c.metadata.get("question"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("(see the responses below)");
+
+        let mut current_positions: Vec<String> =
+            candidates.iter().map(|c| c.content.clone()).collect();
+        let mut round_history: Vec<Vec<String>> = vec![current_positions.clone()];
+        let mut warnings = Vec::new();
+
+        let mut actual_rounds = 0;
+        for round in 1..=self.config.max_rounds {
+            actual_rounds = round;
+
+            // Each participant independently blind-critiques the shuffled,
+            // anonymized positions and revises only its own. `join_all` polls
+            // borrowed provider futures concurrently without requiring the
+            // `'static` lifetime that spawned tasks would need.
+            let attempts = participant_llms.iter().enumerate().map(|(i, llm)| {
+                let prompt = blind_critique_prompt(
+                    question,
+                    &current_positions,
+                    i,
+                    round,
+                    self.config.max_rounds,
+                );
+                async move {
+                    let result = tokio::time::timeout(
+                        llm.options().timeout,
+                        llm.complete(&prompt, Some(&self.config.system_prompt)),
+                    )
+                    .await;
+                    (i, result)
+                }
+            });
+            let mut new_positions = Vec::with_capacity(current_positions.len());
+            let mut refined_indices = Vec::with_capacity(current_positions.len());
+            for (i, result) in join_all(attempts).await {
+                match result {
+                    Ok(Ok(refined)) => {
+                        let refined = extract_final_answer(&refined);
+                        if refined.trim().is_empty() {
+                            warnings.push(format!(
+                                "debate round {round}: participant {i} returned an empty refinement; retained its previous position"
+                            ));
+                            new_positions.push(current_positions[i].clone());
+                        } else {
+                            refined_indices.push(i);
+                            new_positions.push(refined);
+                        }
+                    }
+                    Ok(Err(error)) => {
+                        warnings.push(format!(
+                            "debate round {round}: participant {i} failed ({error}); retained its previous position"
+                        ));
+                        new_positions.push(current_positions[i].clone());
+                    }
+                    Err(_) => {
+                        warnings.push(format!(
+                            "debate round {round}: participant {i} exceeded its request timeout; retained its previous position"
+                        ));
+                        new_positions.push(current_positions[i].clone());
+                    }
+                }
+            }
+
+            // Failed/empty turns retain their old positions for resilience,
+            // but must not count as perfect similarity and fabricate
+            // convergence. Only successful refinements contribute.
+            let similarities: Vec<f64> = refined_indices
+                .iter()
+                .map(|&i| text_similarity(&current_positions[i], &new_positions[i]))
+                .collect();
+            let mean_similarity = (!similarities.is_empty())
+                .then(|| similarities.iter().sum::<f64>() / similarities.len() as f64);
+
+            current_positions = new_positions;
+            round_history.push(current_positions.clone());
+
+            if let Some(mean_similarity) = mean_similarity {
+                tracing::info!(
+                    "Debate round {}/{} complete (mean successful-position similarity: {:.3})",
+                    round,
+                    self.config.max_rounds,
+                    mean_similarity
+                );
+                if mean_similarity >= self.config.convergence_threshold {
+                    tracing::info!(
+                        "Debate converged early at round {} (threshold: {:.2})",
+                        round,
+                        self.config.convergence_threshold
+                    );
+                    break;
+                }
+            } else {
+                tracing::warn!(
+                    "Debate round {}/{} had no successful refinements; convergence not evaluated",
+                    round,
+                    self.config.max_rounds
+                );
+            }
+        }
+
+        self.adjudicate(
+            candidates,
+            &current_positions,
+            judge,
+            actual_rounds,
+            round_history,
+            warnings,
+        )
+        .await
+    }
+
+    /// Adjudicate the final positions with a judge LLM, falling back to
+    /// deterministic text-similarity scoring when the judge output cannot be
+    /// parsed. The fallback never fabricates a perfect agreement score.
+    async fn adjudicate(
+        &self,
+        candidates: &[Candidate],
+        final_positions: &[String],
+        judge: &dyn LlmProvider,
+        actual_rounds: usize,
+        round_history: Vec<Vec<String>>,
+        mut warnings: Vec<String>,
+    ) -> Result<ConsensusResult> {
+        let positions_text = final_positions
+            .iter()
+            .enumerate()
+            .map(|(i, pos)| format!("--- Position {} ---\n{}", i, pos))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let judge_prompt = DEBATE_JUDGE_PROMPT
+            .replace("{count}", &final_positions.len().to_string())
+            .replace("{candidates}", &positions_text);
+
+        let judge_response = judge.complete(&judge_prompt, Some(DEFAULT_JUDGE_SYSTEM)).await?;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("rounds_completed".to_string(), serde_json::json!(actual_rounds));
+        metadata.insert("round_history".to_string(), serde_json::json!(round_history));
+        metadata.insert("blind".to_string(), serde_json::json!(true));
+
+        // Map dissenting final positions back to the originating candidates.
+        let dissent_candidates = |indices: &[usize]| -> Vec<Candidate> {
+            indices.iter().filter_map(|&i| candidates.get(i).cloned()).collect()
+        };
+
+        let (content, agreement_score, dissents, reasoning) =
+            match parse_judge_response(&judge_response) {
+                Ok(parsed) => {
+                    let (valid, dropped): (Vec<usize>, Vec<usize>) =
+                        parsed.dissent_indices.iter().copied().partition(|&i| i < candidates.len());
+                    if !dropped.is_empty() {
+                        warnings.push(format!(
+                            "judge returned out-of-range dissent indices {dropped:?}; dropped"
+                        ));
+                    }
+                    metadata.insert("judge_parse".to_string(), serde_json::json!("structured"));
+                    (
+                        parsed.synthesis,
+                        parsed.agreement_score,
+                        dissent_candidates(&valid),
+                        parsed.reasoning,
+                    )
+                }
+                Err(parse_err) => {
+                    // Deterministic fallback: the most central final position
+                    // (highest mean similarity to the others), with honest
+                    // similarity-based scoring — never a fabricated 1.0.
+                    let consensus_idx = most_central_index(final_positions);
+                    let scores: Vec<f64> = final_positions
+                        .iter()
+                        .map(|p| text_similarity(&final_positions[consensus_idx], p))
+                        .collect();
+                    let avg = scores.iter().sum::<f64>() / scores.len().max(1) as f64;
+                    let dissent_indices: Vec<usize> = scores
+                        .iter()
+                        .enumerate()
+                        .filter(|&(_, &s)| s < 0.3)
+                        .map(|(i, _)| i)
+                        .collect();
+                    metadata.insert("judge_parse".to_string(), serde_json::json!("fallback"));
+                    warnings.push(format!(
+                        "judge response was not valid JSON ({parse_err}); \
+                         consensus picked by text similarity, agreement estimated"
+                    ));
+                    (
+                        final_positions[consensus_idx].clone(),
+                        avg,
+                        dissent_candidates(&dissent_indices),
+                        "Judge response was not in structured format; \
+                         agreement estimated from text similarity"
+                            .to_string(),
+                    )
+                }
+            };
+
+        if !warnings.is_empty() {
+            metadata.insert("warnings".to_string(), serde_json::json!(warnings));
+        }
+
+        Ok(ConsensusResult {
+            content,
+            strategy: self.name().to_string(),
+            agreement_score,
+            candidates: candidates.to_vec(),
+            dissents,
+            reasoning: Some(format!(
+                "{reasoning} (debate completed in {} round(s) of {} maximum)",
+                actual_rounds, self.config.max_rounds,
+            )),
+            metadata,
+        })
+    }
 }
 
 impl Default for MultiRoundDebate {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Build the blind critique prompt for one participant: positions are
+/// anonymized and shuffled with a deterministic per-participant, per-round
+/// permutation so no participant can identify its own position.
+fn blind_critique_prompt(
+    question: &str,
+    positions: &[String],
+    participant_idx: usize,
+    round: usize,
+    max_rounds: usize,
+) -> String {
+    let order = shuffled_indices(positions.len(), participant_idx, round);
+    let positions_text = order
+        .iter()
+        .enumerate()
+        .map(|(label, &pos_idx)| format!("--- Position {} ---\n{}", label + 1, positions[pos_idx]))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    BLIND_CRITIQUE_PROMPT
+        .replace("{question}", question)
+        .replace("{positions}", &positions_text)
+        .replace("{round}", &round.to_string())
+        .replace("{max_rounds}", &max_rounds.to_string())
+}
+
+/// Deterministic permutation of `0..n` seeded by participant and round.
+/// (A simple xorshift — no external RNG dependency, stable across runs.)
+fn shuffled_indices(n: usize, participant_idx: usize, round: usize) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..n).collect();
+    let mut state =
+        ((participant_idx as u64 + 1) << 32) ^ ((round as u64 + 1).wrapping_mul(0x9E37_79B9));
+    for i in (1..n).rev() {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let j = (state % (i as u64 + 1)) as usize;
+        indices.swap(i, j);
+    }
+    indices
+}
+
+/// Extract the text after a `FINAL ANSWER:` marker; fall back to the whole
+/// response when the marker is absent.
+fn extract_final_answer(response: &str) -> String {
+    if let Some(pos) = response.rfind("FINAL ANSWER:") {
+        let answer = response[pos + "FINAL ANSWER:".len()..].trim();
+        if !answer.is_empty() {
+            return answer.to_string();
+        }
+    }
+    response.trim().to_string()
+}
+
+/// Index of the position with the highest mean similarity to all others
+/// (deterministic tie-break: lowest index wins).
+fn most_central_index(positions: &[String]) -> usize {
+    let mut best = 0usize;
+    let mut best_score = f64::NEG_INFINITY;
+    for (i, p) in positions.iter().enumerate() {
+        let score = positions
+            .iter()
+            .enumerate()
+            .filter(|&(j, _)| j != i)
+            .map(|(_, q)| text_similarity(p, q))
+            .sum::<f64>();
+        if score > best_score {
+            best = i;
+            best_score = score;
+        }
+    }
+    best
 }
 
 /// Compute simple similarity between two strings for convergence detection.
@@ -129,6 +456,9 @@ impl ConsensusStrategy for MultiRoundDebate {
         "multi_round_debate"
     }
 
+    /// Single-provider debate: the same LLM refines every position, but each
+    /// position is still refined independently through its own blind-critique
+    /// prompt — never one broadcast rewrite applied to all.
     async fn resolve(
         &self,
         candidates: &[Candidate],
@@ -136,134 +466,29 @@ impl ConsensusStrategy for MultiRoundDebate {
     ) -> Result<ConsensusResult> {
         let llm =
             llm.ok_or_else(|| anyhow::anyhow!("MultiRoundDebate requires an LLM provider"))?;
+        let participants: Vec<&dyn LlmProvider> = candidates.iter().map(|_| llm).collect();
+        self.resolve_with_participants(candidates, &participants, llm).await
+    }
 
-        if candidates.is_empty() {
-            anyhow::bail!("No candidates provided");
+    /// Multi-provider debate: each candidate's position is refined by its own
+    /// model's provider from `participants`, falling back to the judge LLM
+    /// for candidates without a registered provider.
+    async fn resolve_multi(
+        &self,
+        candidates: &[Candidate],
+        llm: Option<&dyn LlmProvider>,
+        participants: Option<&MultiProvider>,
+    ) -> Result<ConsensusResult> {
+        let judge =
+            llm.ok_or_else(|| anyhow::anyhow!("MultiRoundDebate requires an LLM provider"))?;
+
+        let mut participant_llms: Vec<&dyn LlmProvider> = Vec::with_capacity(candidates.len());
+        for c in candidates {
+            let own = c.model.as_deref().and_then(|m| participants.and_then(|p| p.get(m)));
+            participant_llms.push(own.unwrap_or(judge));
         }
 
-        let mut current_positions: Vec<String> =
-            candidates.iter().map(|c| c.content.clone()).collect();
-        let mut round_history: Vec<Vec<String>> = vec![current_positions.clone()];
-
-        // Extract the original question from metadata if available,
-        // otherwise use a generic prompt
-        let question = candidates
-            .first()
-            .and_then(|c| c.metadata.get("question"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("(see the responses below)");
-
-        let mut actual_rounds = 0;
-        for round in 1..=self.config.max_rounds {
-            actual_rounds = round;
-
-            let positions_text = current_positions
-                .iter()
-                .enumerate()
-                .map(|(i, pos)| {
-                    let model =
-                        candidates.get(i).and_then(|c| c.model.as_deref()).unwrap_or("Participant");
-                    format!("--- {} (Position {}) ---\n{}", model, i + 1, pos)
-                })
-                .collect::<Vec<_>>()
-                .join("\n\n");
-
-            let prompt = DEBATE_ROUND_PROMPT
-                .replace("{question}", question)
-                .replace("{positions}", &positions_text)
-                .replace("{round}", &round.to_string())
-                .replace("{max_rounds}", &self.config.max_rounds.to_string());
-
-            // Have the LLM produce a refined position
-            let refined = llm.complete(&prompt, Some(&self.config.system_prompt)).await?;
-
-            // Check convergence: compare refined with each current position
-            let max_similarity = current_positions
-                .iter()
-                .map(|pos| text_similarity(&refined, pos))
-                .fold(0.0_f64, f64::max);
-
-            // Update all positions to the refined one (simplified: single-LLM debate)
-            let new_positions = vec![refined; current_positions.len()];
-            current_positions = new_positions;
-            round_history.push(current_positions.clone());
-
-            tracing::info!(
-                "Debate round {}/{} complete (convergence similarity: {:.3})",
-                round,
-                self.config.max_rounds,
-                max_similarity
-            );
-
-            if max_similarity >= self.config.convergence_threshold {
-                tracing::info!(
-                    "Debate converged early at round {} (threshold: {:.2})",
-                    round,
-                    self.config.convergence_threshold
-                );
-                break;
-            }
-        }
-
-        // The final position is the consensus
-        let final_position = current_positions.into_iter().next().unwrap_or_default();
-
-        // Use an LLM judge to classify agreement/dissent, falling back to
-        // text_similarity if the judge response can't be parsed.
-        tracing::info!("Sending debate synthesis to judge for classification");
-        let candidates_text = candidates
-            .iter()
-            .enumerate()
-            .map(|(i, c)| {
-                let model_info =
-                    c.model.as_ref().map(|m| format!(" (model: {m})")).unwrap_or_default();
-                format!("--- Candidate {}{}---\n{}", i, model_info, c.content)
-            })
-            .collect::<Vec<_>>()
-            .join("\n\n");
-
-        let judge_prompt = DEBATE_JUDGE_PROMPT
-            .replace("{count}", &candidates.len().to_string())
-            .replace("{synthesis}", &final_position)
-            .replace("{candidates}", &candidates_text);
-
-        let judge_response = llm.complete(&judge_prompt, Some(DEFAULT_JUDGE_SYSTEM)).await?;
-
-        let (avg_agreement, dissents) = if let Ok(parsed) = parse_judge_response(&judge_response) {
-            let dissents: Vec<Candidate> =
-                parsed.dissent_indices.iter().filter_map(|&i| candidates.get(i).cloned()).collect();
-            (parsed.agreement_score, dissents)
-        } else {
-            // Fallback: text_similarity scoring
-            let agreement_scores: Vec<f64> =
-                candidates.iter().map(|c| text_similarity(&final_position, &c.content)).collect();
-            let avg = agreement_scores.iter().sum::<f64>() / agreement_scores.len().max(1) as f64;
-            let dissents: Vec<Candidate> = candidates
-                .iter()
-                .zip(agreement_scores.iter())
-                .filter(|&(_, &score)| score < 0.3)
-                .map(|(c, _)| c.clone())
-                .collect();
-            let avg = if dissents.is_empty() { 1.0 } else { avg };
-            (avg, dissents)
-        };
-
-        let mut metadata = HashMap::new();
-        metadata.insert("rounds_completed".to_string(), serde_json::json!(actual_rounds));
-        metadata.insert("round_history".to_string(), serde_json::json!(round_history));
-
-        Ok(ConsensusResult {
-            content: final_position,
-            strategy: self.name().to_string(),
-            agreement_score: avg_agreement,
-            candidates: candidates.to_vec(),
-            dissents,
-            reasoning: Some(format!(
-                "Debate completed in {} round(s) of {} maximum",
-                actual_rounds, self.config.max_rounds,
-            )),
-            metadata,
-        })
+        self.resolve_with_participants(candidates, &participant_llms, judge).await
     }
 }
 
@@ -272,31 +497,152 @@ mod tests {
     use super::*;
     use crate::provider::MockProvider;
 
-    #[tokio::test]
-    async fn debate_converges() {
-        let judge_json = serde_json::json!({
-            "synthesis": "The refined consensus answer after debate.",
-            "reasoning": "Both candidates broadly agreed.",
-            "agreement_score": 0.85,
-            "dissent_indices": []
-        });
+    struct FailingProvider;
 
+    #[async_trait]
+    impl LlmProvider for FailingProvider {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+            anyhow::bail!("simulated participant failure")
+        }
+    }
+
+    fn judge_json(score: f64) -> String {
+        serde_json::json!({
+            "synthesis": "The adjudicated consensus answer.",
+            "reasoning": "Positions broadly agreed.",
+            "agreement_score": score,
+            "dissent_indices": []
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn debate_independent_positions_not_broadcast() {
+        // Two participants get different refinements; the final positions must
+        // NOT collapse into one broadcast rewrite.
         let provider = MockProvider::new(vec![
-            "The refined consensus answer after debate.".to_string(),
-            judge_json.to_string(),
+            "Critique...\nFINAL ANSWER: Refined position Alpha".to_string(),
+            "Critique...\nFINAL ANSWER: Refined position Beta".to_string(),
+            judge_json(0.6),
         ]);
         let candidates = vec![
             Candidate::new("Answer A from model 1").with_model("model-1"),
             Candidate::new("Answer B from model 2").with_model("model-2"),
         ];
 
-        let strategy = MultiRoundDebate::new().with_rounds(3);
+        let strategy = MultiRoundDebate::new().with_rounds(1);
         let result = strategy.resolve(&candidates, Some(&provider)).await.unwrap();
 
         assert_eq!(result.strategy, "multi_round_debate");
-        assert!(!result.content.is_empty());
+        assert_eq!(result.content, "The adjudicated consensus answer.");
+        // Honest scoring: the judge's reported score is kept, not inflated.
+        assert_eq!(result.agreement_score, 0.6);
+        let history = result.metadata["round_history"].as_array().unwrap();
+        let last = history.last().unwrap().as_array().unwrap();
+        let positions: Vec<&str> = last.iter().filter_map(|p| p.as_str()).collect();
+        assert_eq!(positions, vec!["Refined position Alpha", "Refined position Beta"]);
+        assert_eq!(result.metadata["blind"], serde_json::json!(true));
+        assert_eq!(result.metadata["judge_parse"], serde_json::json!("structured"));
+    }
+
+    #[tokio::test]
+    async fn debate_multi_provider_uses_each_models_own_provider() {
+        // resolve_multi must route each candidate's refinement to its own provider.
+        let multi = MultiProvider::new()
+            .add("model-1", MockProvider::fixed("FINAL ANSWER: From provider one"))
+            .add("model-2", MockProvider::fixed("FINAL ANSWER: From provider two"));
+        let judge = MockProvider::fixed(judge_json(0.7));
+
+        let candidates = vec![
+            Candidate::new("Answer A").with_model("model-1"),
+            Candidate::new("Answer B").with_model("model-2"),
+        ];
+
+        let strategy = MultiRoundDebate::new().with_rounds(1);
+        let result = strategy.resolve_multi(&candidates, Some(&judge), Some(&multi)).await.unwrap();
+
+        let history = result.metadata["round_history"].as_array().unwrap();
+        let last = history.last().unwrap().as_array().unwrap();
+        let positions: Vec<&str> = last.iter().filter_map(|p| p.as_str()).collect();
+        assert_eq!(positions, vec!["From provider one", "From provider two"]);
+    }
+
+    #[tokio::test]
+    async fn debate_retains_position_when_one_participant_fails() {
+        let failing = FailingProvider;
+        let healthy = MockProvider::fixed("FINAL ANSWER: Healthy revision");
+        let judge = MockProvider::fixed(judge_json(0.5));
+        let candidates = vec![Candidate::new("Original A"), Candidate::new("Original B")];
+        let participants: Vec<&dyn LlmProvider> = vec![&failing, &healthy];
+
+        let result = MultiRoundDebate::new()
+            .with_rounds(1)
+            .resolve_with_participants(&candidates, &participants, &judge)
+            .await
+            .unwrap();
+
+        let last = result.metadata["round_history"].as_array().unwrap().last().unwrap();
+        assert_eq!(last[0], serde_json::json!("Original A"));
+        assert_eq!(last[1], serde_json::json!("Healthy revision"));
+        let warnings = result.metadata["warnings"].as_array().unwrap();
+        assert!(warnings.iter().any(|warning| warning.as_str().unwrap().contains("participant 0")));
+    }
+
+    #[tokio::test]
+    async fn all_failed_participants_never_fabricate_early_convergence() {
+        let failing_a = FailingProvider;
+        let failing_b = FailingProvider;
+        let judge = MockProvider::fixed(judge_json(0.2));
+        let candidates = vec![Candidate::new("Original A"), Candidate::new("Original B")];
+        let participants: Vec<&dyn LlmProvider> = vec![&failing_a, &failing_b];
+
+        let result = MultiRoundDebate::new()
+            .with_rounds(3)
+            .resolve_with_participants(&candidates, &participants, &judge)
+            .await
+            .unwrap();
+
+        assert_eq!(result.metadata["rounds_completed"], serde_json::json!(3));
+        assert_eq!(result.metadata["round_history"].as_array().unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn debate_judge_fallback_is_honest() {
+        let provider = MockProvider::new(vec![
+            "FINAL ANSWER: Refined".to_string(),
+            "FINAL ANSWER: Refined".to_string(),
+            "not json at all".to_string(),
+        ]);
+        let candidates = vec![Candidate::new("A"), Candidate::new("A")];
+
+        let strategy = MultiRoundDebate::new().with_rounds(1);
+        let result = strategy.resolve(&candidates, Some(&provider)).await.unwrap();
+
+        assert_eq!(result.metadata["judge_parse"], serde_json::json!("fallback"));
+        assert!(result.metadata.contains_key("warnings"));
+        // Identical positions → similarity-based agreement of 1.0 is legitimate
+        // here, but it comes from measurement, not from fabrication.
         assert_eq!(result.agreement_score, 1.0);
-        assert!(result.dissents.is_empty());
+        assert_eq!(result.content, "Refined");
+    }
+
+    #[tokio::test]
+    async fn debate_converges_early_when_positions_stabilize() {
+        // Every response is identical, so round 1 already converges; the judge
+        // (response 3) adjudicates. max_rounds=5 must not burn extra calls.
+        let provider = MockProvider::new(vec![
+            "Same answer".to_string(),
+            "Same answer".to_string(),
+            judge_json(0.9),
+            "unused".to_string(),
+        ]);
+        let candidates = vec![Candidate::new("Same answer"), Candidate::new("Same answer")];
+
+        let strategy = MultiRoundDebate::new().with_rounds(5);
+        let result = strategy.resolve(&candidates, Some(&provider)).await.unwrap();
+
+        assert_eq!(result.metadata["rounds_completed"], serde_json::json!(1));
+        assert_eq!(result.agreement_score, 0.9);
     }
 
     #[tokio::test]
@@ -305,5 +651,31 @@ mod tests {
         let strategy = MultiRoundDebate::new();
         let result = strategy.resolve(&candidates, None).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn shuffle_is_deterministic_and_a_permutation() {
+        let a = shuffled_indices(4, 0, 1);
+        let b = shuffled_indices(4, 0, 1);
+        assert_eq!(a, b);
+        let mut sorted = a.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn shuffle_differs_per_participant() {
+        // With enough positions, different participants should (deterministically)
+        // see different orders, so positions cannot be tracked across the panel.
+        let a = shuffled_indices(6, 0, 1);
+        let b = shuffled_indices(6, 1, 1);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn extract_final_answer_marker() {
+        assert_eq!(extract_final_answer("critique\nFINAL ANSWER: real answer"), "real answer");
+        assert_eq!(extract_final_answer("no marker here"), "no marker here");
+        assert_eq!(extract_final_answer("FINAL ANSWER:\n"), "FINAL ANSWER:");
     }
 }

--- a/crates/caucus-core/src/strategy/judge.rs
+++ b/crates/caucus-core/src/strategy/judge.rs
@@ -100,30 +100,61 @@ impl ConsensusStrategy for JudgeSynthesis {
         let response = llm.complete(&prompt, Some(&self.system_prompt)).await?;
 
         // Try to parse structured JSON response
-        if let Ok(parsed) = parse_judge_response(&response) {
-            let dissents: Vec<Candidate> =
-                parsed.dissent_indices.iter().filter_map(|&i| candidates.get(i).cloned()).collect();
+        match parse_judge_response(&response) {
+            Ok(parsed) => {
+                // Out-of-range dissent indices are dropped, but recorded honestly.
+                let (valid, dropped): (Vec<usize>, Vec<usize>) =
+                    parsed.dissent_indices.iter().copied().partition(|&i| i < candidates.len());
+                let dissents: Vec<Candidate> =
+                    valid.iter().filter_map(|&i| candidates.get(i).cloned()).collect();
 
-            Ok(ConsensusResult {
-                content: parsed.synthesis,
-                strategy: self.name().to_string(),
-                agreement_score: parsed.agreement_score,
-                candidates: candidates.to_vec(),
-                dissents,
-                reasoning: Some(parsed.reasoning),
-                metadata: HashMap::new(),
-            })
-        } else {
-            // Fallback: use the raw response as the synthesis
-            Ok(ConsensusResult {
-                content: response,
-                strategy: self.name().to_string(),
-                agreement_score: 1.0,
-                candidates: candidates.to_vec(),
-                dissents: vec![],
-                reasoning: Some("Judge response was not in structured format".to_string()),
-                metadata: HashMap::new(),
-            })
+                let mut metadata = HashMap::new();
+                metadata.insert("judge_parse".to_string(), serde_json::json!("structured"));
+                if !dropped.is_empty() {
+                    metadata.insert(
+                        "warnings".to_string(),
+                        serde_json::json!([format!(
+                            "judge returned out-of-range dissent indices {dropped:?}; dropped"
+                        )]),
+                    );
+                }
+
+                Ok(ConsensusResult {
+                    content: parsed.synthesis,
+                    strategy: self.name().to_string(),
+                    agreement_score: parsed.agreement_score,
+                    candidates: candidates.to_vec(),
+                    dissents,
+                    reasoning: Some(parsed.reasoning),
+                    metadata,
+                })
+            }
+            Err(parse_err) => {
+                // Fallback: use the raw response as the synthesis. Do NOT fabricate
+                // an agreement score — we could not measure agreement, so report
+                // the neutral midpoint and mark the result as unparsed.
+                let mut metadata = HashMap::new();
+                metadata.insert("judge_parse".to_string(), serde_json::json!("fallback"));
+                metadata.insert(
+                    "warnings".to_string(),
+                    serde_json::json!([format!(
+                        "judge response was not valid JSON ({parse_err}); \
+                         agreement score is unknown and reported as 0.5"
+                    )]),
+                );
+                Ok(ConsensusResult {
+                    content: response,
+                    strategy: self.name().to_string(),
+                    agreement_score: 0.5,
+                    candidates: candidates.to_vec(),
+                    dissents: vec![],
+                    reasoning: Some(
+                        "Judge response was not in structured format; agreement unmeasured"
+                            .to_string(),
+                    ),
+                    metadata,
+                })
+            }
         }
     }
 }
@@ -138,25 +169,26 @@ pub(crate) struct JudgeResponse {
 }
 
 pub(crate) fn parse_judge_response(response: &str) -> Result<JudgeResponse> {
-    // Try direct parse first
-    if let Ok(mut parsed) = serde_json::from_str::<JudgeResponse>(response) {
-        if parsed.dissent_indices.is_empty() {
-            parsed.agreement_score = 1.0;
-        }
+    fn normalize(mut parsed: JudgeResponse) -> JudgeResponse {
+        // Clamp to the valid range, but never override the judge's reported
+        // score based on dissent count — an empty dissent list does not imply
+        // perfect agreement.
         parsed.agreement_score = parsed.agreement_score.clamp(0.0, 1.0);
-        return Ok(parsed);
+        parsed
+    }
+
+    // Try direct parse first
+    if let Ok(parsed) = serde_json::from_str::<JudgeResponse>(response) {
+        return Ok(normalize(parsed));
     }
     // Try to extract JSON from markdown code block
     if let Some(start) = response.find('{')
         && let Some(end) = response.rfind('}')
+        && start <= end
     {
         let json_str = &response[start..=end];
-        if let Ok(mut parsed) = serde_json::from_str::<JudgeResponse>(json_str) {
-            if parsed.dissent_indices.is_empty() {
-                parsed.agreement_score = 1.0;
-            }
-            parsed.agreement_score = parsed.agreement_score.clamp(0.0, 1.0);
-            return Ok(parsed);
+        if let Ok(parsed) = serde_json::from_str::<JudgeResponse>(json_str) {
+            return Ok(normalize(parsed));
         }
     }
     anyhow::bail!("Could not parse judge response as JSON")
@@ -197,5 +229,75 @@ mod tests {
         let strategy = JudgeSynthesis::new();
         let result = strategy.resolve(&candidates, None).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_keeps_reported_score_with_no_dissents() {
+        // An empty dissent list must NOT inflate the agreement score to 1.0.
+        let response = serde_json::json!({
+            "synthesis": "s",
+            "reasoning": "r",
+            "agreement_score": 0.85,
+            "dissent_indices": []
+        });
+        let parsed = parse_judge_response(&response.to_string()).unwrap();
+        assert_eq!(parsed.agreement_score, 0.85);
+        assert!(parsed.dissent_indices.is_empty());
+    }
+
+    #[test]
+    fn parse_clamps_out_of_range_score() {
+        let response = serde_json::json!({
+            "synthesis": "s",
+            "reasoning": "r",
+            "agreement_score": 7.3,
+            "dissent_indices": []
+        });
+        let parsed = parse_judge_response(&response.to_string()).unwrap();
+        assert_eq!(parsed.agreement_score, 1.0);
+    }
+
+    #[test]
+    fn parse_extracts_json_from_markdown_fence() {
+        let response = "Here is my evaluation:\n```json\n{\"synthesis\":\"s\",\"reasoning\":\"r\",\"agreement_score\":0.4}\n```";
+        let parsed = parse_judge_response(response).unwrap();
+        assert_eq!(parsed.agreement_score, 0.4);
+    }
+
+    #[test]
+    fn malformed_brace_order_returns_error_instead_of_panicking() {
+        assert!(parse_judge_response("closing } before opening {").is_err());
+    }
+
+    #[tokio::test]
+    async fn judge_fallback_does_not_fabricate_agreement() {
+        let provider = MockProvider::fixed("This is not JSON at all.");
+        let candidates = vec![Candidate::new("A"), Candidate::new("B")];
+
+        let strategy = JudgeSynthesis::new();
+        let result = strategy.resolve(&candidates, Some(&provider)).await.unwrap();
+
+        // Unparseable judge output → neutral score, never a fabricated 1.0.
+        assert_eq!(result.agreement_score, 0.5);
+        assert_eq!(result.metadata["judge_parse"], serde_json::json!("fallback"));
+        assert!(result.metadata["warnings"].as_array().unwrap().len() == 1);
+    }
+
+    #[tokio::test]
+    async fn judge_drops_out_of_range_dissent_indices() {
+        let judge_response = serde_json::json!({
+            "synthesis": "s",
+            "reasoning": "r",
+            "agreement_score": 0.6,
+            "dissent_indices": [1, 99]
+        });
+        let provider = MockProvider::fixed(judge_response.to_string());
+        let candidates = vec![Candidate::new("A"), Candidate::new("B")];
+
+        let strategy = JudgeSynthesis::new();
+        let result = strategy.resolve(&candidates, Some(&provider)).await.unwrap();
+
+        assert_eq!(result.dissents.len(), 1);
+        assert!(result.metadata.contains_key("warnings"));
     }
 }

--- a/crates/caucus-core/src/strategy/vote.rs
+++ b/crates/caucus-core/src/strategy/vote.rs
@@ -33,7 +33,7 @@ impl MajorityVote {
 }
 
 /// Compute normalized similarity between two strings using bigram overlap.
-fn bigram_similarity(a: &str, b: &str) -> f64 {
+pub(crate) fn bigram_similarity(a: &str, b: &str) -> f64 {
     let a = a.to_lowercase();
     let b = b.to_lowercase();
 
@@ -169,16 +169,27 @@ impl WeightedVote {
     }
 
     fn weight_for(&self, candidate: &Candidate) -> f64 {
-        // Priority: confidence > model weight > default
-        if let Some(conf) = candidate.confidence {
+        // Priority: confidence > model weight > default. Provider output and
+        // HTTP input can contain non-finite or non-positive floating-point
+        // values; never let those reach sorting or the agreement division.
+        if let Some(conf) = candidate.confidence
+            && conf.is_finite()
+            && conf > 0.0
+        {
             return conf;
         }
         if let Some(model) = &candidate.model
             && let Some(w) = self.model_weights.get(model)
+            && w.is_finite()
+            && *w > 0.0
         {
             return *w;
         }
-        self.default_weight
+        if self.default_weight.is_finite() && self.default_weight > 0.0 {
+            self.default_weight
+        } else {
+            1.0
+        }
     }
 }
 
@@ -317,6 +328,21 @@ mod tests {
         let strategy = WeightedVote::new().with_threshold(0.3);
         let result = strategy.resolve(&candidates, None).await.unwrap();
         assert_eq!(result.content, "Answer A");
+    }
+
+    #[tokio::test]
+    async fn weighted_vote_sanitizes_non_finite_and_non_positive_weights() {
+        let candidates = vec![
+            Candidate::new("Answer A").with_confidence(f64::NAN),
+            Candidate::new("Answer B completely different").with_confidence(f64::INFINITY),
+            Candidate::new("Answer C also different").with_confidence(-2.0),
+        ];
+        let strategy =
+            WeightedVote::new().with_threshold(0.9).with_model_weight("unused", f64::NAN);
+        let result = strategy.resolve(&candidates, None).await.unwrap();
+
+        assert!(result.agreement_score.is_finite());
+        assert!((0.0..=1.0).contains(&result.agreement_score));
     }
 
     #[tokio::test]

--- a/crates/caucus-core/src/types.rs
+++ b/crates/caucus-core/src/types.rs
@@ -5,6 +5,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub use crate::error::{ErrorKind, ProviderError};
+
 /// A single response from an LLM (or any source) submitted for consensus.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Candidate {
@@ -59,6 +61,68 @@ pub struct ConsensusResult {
     pub metadata: HashMap<String, Value>,
 }
 
+/// The transport a provider uses to reach a model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Transport {
+    /// Remote HTTP API (OpenAI-compatible, Anthropic, Gemini, ...).
+    Api,
+    /// A local CLI invoked with an explicit argv vector (never a shell).
+    Command,
+    /// A locally-running OpenAI-compatible server (Ollama, LM Studio, ...).
+    LocalServer,
+    /// Agent Client Protocol. Recognized but not supported by this build.
+    Acp,
+}
+
+impl std::fmt::Display for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Api => "api",
+            Self::Command => "command",
+            Self::LocalServer => "local-server",
+            Self::Acp => "acp",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Metadata about a single completion attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseMeta {
+    /// Model/provider name.
+    pub provider: String,
+    pub transport: Transport,
+    pub latency_ms: u64,
+    /// True when the output was truncated by a byte limit.
+    pub truncated: bool,
+    /// Error classification when the attempt failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorKind>,
+}
+
+/// The outcome of a single completion attempt: content plus normalized metadata.
+#[derive(Debug)]
+pub struct CompleteOutcome {
+    pub result: Result<String>,
+    pub meta: ResponseMeta,
+}
+
+/// Per-provider tunables for timeouts and output limits.
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderOptions {
+    /// Wall-clock timeout for one completion attempt.
+    pub timeout: std::time::Duration,
+    /// Maximum bytes of output to retain; excess is truncated.
+    pub max_output_bytes: usize,
+}
+
+impl Default for ProviderOptions {
+    fn default() -> Self {
+        Self { timeout: std::time::Duration::from_secs(120), max_output_bytes: 1024 * 1024 }
+    }
+}
+
 /// Trait for LLM providers. Users implement this to plug in any LLM backend.
 #[async_trait]
 pub trait LlmProvider: Send + Sync {
@@ -69,6 +133,41 @@ pub trait LlmProvider: Send + Sync {
     /// Default implementation returns an error indicating embeddings aren't supported.
     async fn embed(&self, _texts: &[String]) -> Result<Vec<Vec<f64>>> {
         anyhow::bail!("Embedding not supported by this provider")
+    }
+
+    /// Which transport this provider uses.
+    fn transport(&self) -> Transport {
+        Transport::Api
+    }
+
+    /// Timeout and output-limit options for this provider.
+    fn options(&self) -> ProviderOptions {
+        ProviderOptions::default()
+    }
+
+    /// Complete and report normalized metadata (latency, transport, error kind).
+    /// The default implementation wraps [`LlmProvider::complete`] with timing
+    /// and error classification.
+    async fn complete_meta(
+        &self,
+        name: &str,
+        prompt: &str,
+        system: Option<&str>,
+    ) -> CompleteOutcome {
+        let start = std::time::Instant::now();
+        let result = self.complete(prompt, system).await;
+        let latency_ms = start.elapsed().as_millis() as u64;
+        let error = result.as_ref().err().map(ProviderError::classify);
+        CompleteOutcome {
+            result,
+            meta: ResponseMeta {
+                provider: name.to_string(),
+                transport: self.transport(),
+                latency_ms,
+                truncated: false,
+                error,
+            },
+        }
     }
 }
 
@@ -81,6 +180,52 @@ impl LlmProvider for Box<dyn LlmProvider> {
 
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f64>>> {
         self.as_ref().embed(texts).await
+    }
+
+    fn transport(&self) -> Transport {
+        self.as_ref().transport()
+    }
+
+    fn options(&self) -> ProviderOptions {
+        self.as_ref().options()
+    }
+
+    async fn complete_meta(
+        &self,
+        name: &str,
+        prompt: &str,
+        system: Option<&str>,
+    ) -> CompleteOutcome {
+        self.as_ref().complete_meta(name, prompt, system).await
+    }
+}
+
+// Allow Arc<dyn LlmProvider> to be used as an LlmProvider.
+#[async_trait]
+impl LlmProvider for std::sync::Arc<dyn LlmProvider> {
+    async fn complete(&self, prompt: &str, system: Option<&str>) -> Result<String> {
+        self.as_ref().complete(prompt, system).await
+    }
+
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f64>>> {
+        self.as_ref().embed(texts).await
+    }
+
+    fn transport(&self) -> Transport {
+        self.as_ref().transport()
+    }
+
+    fn options(&self) -> ProviderOptions {
+        self.as_ref().options()
+    }
+
+    async fn complete_meta(
+        &self,
+        name: &str,
+        prompt: &str,
+        system: Option<&str>,
+    ) -> CompleteOutcome {
+        self.as_ref().complete_meta(name, prompt, system).await
     }
 }
 
@@ -97,4 +242,18 @@ pub trait ConsensusStrategy: Send + Sync {
         candidates: &[Candidate],
         llm: Option<&dyn LlmProvider>,
     ) -> Result<ConsensusResult>;
+
+    /// Resolve with access to one provider per participant, enabling genuinely
+    /// independent multi-provider behavior (e.g. blind debate where each
+    /// participant refines its own position). The default implementation
+    /// ignores `participants` and falls back to [`ConsensusStrategy::resolve`].
+    async fn resolve_multi(
+        &self,
+        candidates: &[Candidate],
+        llm: Option<&dyn LlmProvider>,
+        participants: Option<&crate::provider::MultiProvider>,
+    ) -> Result<ConsensusResult> {
+        let _ = participants;
+        self.resolve(candidates, llm).await
+    }
 }

--- a/crates/caucus-core/tests/fixtures/legacy_deep_profile.toml
+++ b/crates/caucus-core/tests/fixtures/legacy_deep_profile.toml
@@ -1,0 +1,15 @@
+# Legacy profile schema (pre-`members`), captured verbatim from a real
+# ~/.config/caucus/config.toml. The loader migrates this in memory with
+# warnings; the file on disk is never modified.
+[profiles.deep]
+models = [
+  "claude:claude-opus-4-6@xhigh",
+  "claude:claude-fable-5@xhigh",
+  "codex@xhigh",
+  "glm:zai-coding-plan/glm-5.2@xhigh",
+  "kimi:kimi-code/k3@high",
+]
+judge = "claude:claude-fable-5@xhigh"
+quorum = 4
+timeout_seconds = 240
+deadline_seconds = 900

--- a/crates/caucus-core/tests/integration_test.rs
+++ b/crates/caucus-core/tests/integration_test.rs
@@ -46,7 +46,7 @@ async fn test_judge_synthesis_with_mock() {
 
     let result = consensus(&candidates, "judge", Some(&provider)).await.unwrap();
     assert!(result.content.contains("Paris"));
-    assert_eq!(result.agreement_score, 1.0);
+    assert_eq!(result.agreement_score, 0.85);
 }
 
 #[tokio::test]

--- a/crates/caucus-core/tests/provider_profile_test.rs
+++ b/crates/caucus-core/tests/provider_profile_test.rs
@@ -1,0 +1,385 @@
+//! Integration tests for the provider/profile vertical slice:
+//! process execution, adapters, discovery, config, and profiles.
+
+use std::time::Duration;
+
+use caucus_core::adapters::{
+    self, AdapterOverrides, CommandProvider, CommandSpec, Effort, MemberSpec, PromptDelivery,
+    Readiness, Stability, Utility, build_invocation, build_invocation_with,
+};
+use caucus_core::config::Config;
+use caucus_core::error::{ErrorKind, ProviderError};
+use caucus_core::process::{ProcessLimits, ProcessSpec, run_argv};
+use caucus_core::types::{LlmProvider, Transport};
+
+fn member(spec: &str) -> MemberSpec {
+    MemberSpec::parse(spec).unwrap()
+}
+
+#[test]
+fn deep_council_members_and_metadata_are_exact() {
+    let council = Config::default().resolve_profile(Some("deep")).unwrap();
+    assert_eq!(council.name, "deep");
+
+    let rendered: Vec<String> = council.members.iter().map(|m| m.to_string()).collect();
+    assert_eq!(
+        rendered,
+        vec![
+            "claude:opus@xhigh",
+            "claude:claude-fable-5@xhigh",
+            "codex:default@xhigh",
+            "opencode:zai-coding-plan/glm-5.2@xhigh",
+            "kimi:kimi-code/k3@high",
+        ]
+    );
+
+    assert_eq!(council.strategy, "judge");
+    assert_eq!(council.quorum, 3);
+    assert_eq!(council.deadline_secs, Some(600));
+    assert_eq!(council.description.as_deref(), Some("Broad frontier panel judged by a chair"));
+    assert_eq!(council.budget_usd, None);
+}
+
+#[test]
+fn member_spec_parse_is_exact() {
+    let m = member("opencode:zai-coding-plan/glm-5.2@xhigh");
+    assert_eq!(m.utility, Utility::Opencode);
+    assert_eq!(m.model, "zai-coding-plan/glm-5.2");
+    assert_eq!(m.effort, Some(Effort::Xhigh));
+    assert_eq!(m.to_string(), "opencode:zai-coding-plan/glm-5.2@xhigh");
+
+    // Effort is optional; the model pin is verbatim, never normalized.
+    let m = member("codex:Exact-Model.Name_123");
+    assert_eq!(m.utility, Utility::Codex);
+    assert_eq!(m.model, "Exact-Model.Name_123");
+    assert_eq!(m.effort, None);
+    assert_eq!(m.to_string(), "codex:Exact-Model.Name_123");
+
+    // Malformed specs are rejected.
+    assert!(MemberSpec::parse("opus@high").is_err()); // missing `:`
+    assert!(MemberSpec::parse("bogus:model@high").is_err()); // unknown utility
+    assert!(MemberSpec::parse("claude:@high").is_err()); // empty model pin
+    assert!(MemberSpec::parse("claude:mo del").is_err()); // whitespace in pin
+}
+
+#[test]
+fn member_spec_serde_preserves_exact_model_and_validates() {
+    let json = r#"{"utility":"claude","model":"claude-opus-4-1-20250805","effort":"xhigh"}"#;
+    let m: MemberSpec = serde_json::from_str(json).unwrap();
+    assert_eq!(m.utility, Utility::Claude);
+    assert_eq!(m.model, "claude-opus-4-1-20250805");
+    assert_eq!(m.effort, Some(Effort::Xhigh));
+
+    let round_tripped: MemberSpec =
+        serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
+    assert_eq!(round_tripped, m);
+
+    // Serde runs the same validation as parse: unsupported effort fails.
+    let bad = r#"{"utility":"kimi","model":"k3","effort":"medium"}"#;
+    assert!(serde_json::from_str::<MemberSpec>(bad).is_err());
+}
+
+#[test]
+fn member_spec_rejects_invalid_effort() {
+    // Unknown effort value.
+    assert!(MemberSpec::parse("claude:opus@ludicrous").is_err());
+
+    // Known value the utility does not support natively; the error names
+    // what is supported.
+    let err = MemberSpec::parse("kimi:kimi-code/k3@xhigh").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("xhigh"), "got: {msg}");
+    assert!(msg.contains("low, high, max"), "got: {msg}");
+
+    let err = MemberSpec::parse("codex:gpt-5@max").unwrap_err();
+    assert!(err.to_string().contains("minimal, low, medium, high, xhigh"));
+
+    // Effort on an adapter with no effort support at all.
+    let err = MemberSpec::parse("ollama:llama3.2@high").unwrap_err();
+    assert!(err.to_string().contains("does not support effort"));
+}
+
+#[test]
+fn build_invocation_claude_argv_and_delivery() {
+    let inv = build_invocation(&member("claude:opus@xhigh")).unwrap();
+    assert_eq!(inv.argv(), ["claude", "-p", "--model", "opus", "--effort", "xhigh"]);
+    assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+
+    // Without effort the flag is omitted entirely.
+    let inv = build_invocation(&member("claude:opus")).unwrap();
+    assert_eq!(inv.argv(), ["claude", "-p", "--model", "opus"]);
+}
+
+#[test]
+fn build_invocation_codex_config_override_and_default_omission() {
+    // Effort is delivered as a `-c model_reasoning_effort="..."` config
+    // override; the prompt goes to stdin.
+    let inv = build_invocation(&member("codex:gpt-5.6-sol@xhigh")).unwrap();
+    assert_eq!(
+        inv.argv(),
+        [
+            "codex",
+            "exec",
+            "--skip-git-repo-check",
+            "-m",
+            "gpt-5.6-sol",
+            "-c",
+            "model_reasoning_effort=\"xhigh\""
+        ]
+    );
+    assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Stdin);
+
+    // The `default` model omits `-m` entirely.
+    let inv = build_invocation(&member("codex:default@minimal")).unwrap();
+    assert_eq!(
+        inv.argv(),
+        ["codex", "exec", "--skip-git-repo-check", "-c", "model_reasoning_effort=\"minimal\""]
+    );
+    let inv = build_invocation(&member("codex:default")).unwrap();
+    assert_eq!(inv.argv(), ["codex", "exec", "--skip-git-repo-check"]);
+}
+
+#[test]
+fn build_invocation_opencode_variant() {
+    let inv = build_invocation(&member("opencode:zai-coding-plan/glm-5.2@xhigh")).unwrap();
+    assert_eq!(
+        inv.argv(),
+        ["opencode", "run", "-m", "zai-coding-plan/glm-5.2", "--variant", "xhigh"]
+    );
+    assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+
+    let inv = build_invocation(&member("opencode:glm-5")).unwrap();
+    assert_eq!(inv.argv(), ["opencode", "run", "-m", "glm-5"]);
+}
+
+#[test]
+fn build_invocation_grok_subscription_cli() {
+    let inv = build_invocation(&member("grok:grok-4.5@high")).unwrap();
+    assert_eq!(
+        inv.argv(),
+        [
+            "grok",
+            "--model",
+            "grok-4.5",
+            "--yolo",
+            "--sandbox",
+            "read-only",
+            "--no-subagents",
+            "--output-format",
+            "plain",
+            "--reasoning-effort",
+            "high",
+            "-p",
+        ]
+    );
+    assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+}
+
+#[test]
+fn build_invocation_kimi_effort_uses_env_override() {
+    let inv = build_invocation(&member("kimi:kimi-code/k3@high")).unwrap();
+    let argv = inv.argv();
+
+    // The installed Kimi CLI 0.27.0 has no `--config-file` flag (it exits
+    // with "unknown option"), and effort never appears on argv.
+    assert!(!argv.iter().any(|a| a == "--config-file"));
+    assert!(!argv.iter().any(|a| a == "high"));
+    assert_eq!(argv, ["kimi", "-m", "kimi-code/k3", "-p"]);
+    assert_eq!(inv.spec.prompt_delivery, PromptDelivery::Arg);
+
+    // Effort rides the documented, non-secret KIMI_MODEL_THINKING_EFFORT
+    // override, applied to the child process only.
+    assert_eq!(inv.spec.env, vec![(caucus_core::KIMI_EFFORT_ENV.to_string(), "high".to_string())],);
+}
+
+#[test]
+fn build_invocation_kimi_without_effort_has_no_env() {
+    let inv = build_invocation(&member("kimi:kimi-code/k3")).unwrap();
+    assert_eq!(inv.argv(), ["kimi", "-m", "kimi-code/k3", "-p"]);
+    assert!(inv.spec.env.is_empty());
+}
+
+#[test]
+fn build_invocation_binary_path_override_replaces_program_only() {
+    let overrides =
+        AdapterOverrides { binary_path: Some("/opt/claude".into()), ..Default::default() };
+    let inv = build_invocation_with(&member("claude:opus@max"), &overrides).unwrap();
+    assert_eq!(inv.argv(), ["/opt/claude", "-p", "--model", "opus", "--effort", "max"]);
+}
+
+#[test]
+fn descriptors_cover_transports_and_stability() {
+    let descriptors = adapters::descriptors();
+    for transport in [Transport::Api, Transport::Command, Transport::LocalServer, Transport::Acp] {
+        assert!(
+            descriptors.iter().any(|d| d.transport == transport),
+            "no adapter descriptor for {transport}"
+        );
+    }
+
+    let stable: Vec<&str> =
+        descriptors.iter().filter(|d| d.stability == Stability::Stable).map(|d| d.id).collect();
+    assert_eq!(stable, ["claude", "codex", "ollama", "lmstudio"]);
+
+    let experimental: Vec<&str> = descriptors
+        .iter()
+        .filter(|d| d.stability == Stability::Experimental)
+        .map(|d| d.id)
+        .collect();
+    assert_eq!(experimental, ["kimi", "opencode", "gemini", "grok", "acp"]);
+}
+
+#[tokio::test]
+async fn discover_reports_every_adapter_with_honest_readiness() {
+    let found = adapters::discover().await;
+    assert_eq!(found.len(), adapters::descriptors().len());
+
+    // ACP is recognized but never ready in this build.
+    let acp = found.iter().find(|d| d.descriptor.id == "acp").unwrap();
+    assert!(matches!(acp.readiness, Readiness::Unsupported(_)));
+    assert!(!acp.readiness.is_ready());
+
+    // The remote Gemini API is ready only when its key variable is actually set
+    // (the value itself is never inspected).
+    let gemini = found.iter().find(|d| d.descriptor.id == "gemini").unwrap();
+    match std::env::var_os("GEMINI_API_KEY") {
+        Some(v) if !v.is_empty() => assert!(gemini.readiness.is_ready(), "gemini"),
+        _ => assert_eq!(gemini.readiness, Readiness::MissingApiKey("GEMINI_API_KEY")),
+    }
+
+    // Grok uses the installed subscription CLI, never an API key.
+    let grok = found.iter().find(|d| d.descriptor.id == "grok").unwrap();
+    assert!(matches!(grok.readiness, Readiness::Ready | Readiness::MissingBinary("grok")));
+}
+
+#[test]
+fn legacy_deep_profile_fixture_migrates_with_warnings() {
+    // The exact legacy schema found in a real ~/.config/caucus/config.toml.
+    let text = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/legacy_deep_profile.toml"
+    ))
+    .expect("legacy fixture must exist");
+    let config = Config::from_toml_str(&text).unwrap();
+
+    let council = config.resolve_profile(Some("deep")).unwrap();
+    let rendered: Vec<String> = council.members.iter().map(|m| m.to_string()).collect();
+    assert_eq!(
+        rendered,
+        vec![
+            "claude:claude-opus-4-6@xhigh",
+            "claude:claude-fable-5@xhigh",
+            "codex:default@xhigh",
+            "opencode:zai-coding-plan/glm-5.2@xhigh",
+            "kimi:kimi-code/k3@high",
+        ]
+    );
+    // Judge meaning survives the migration.
+    assert_eq!(
+        council.judge.as_ref().map(ToString::to_string).as_deref(),
+        Some("claude:claude-fable-5@xhigh")
+    );
+    assert_eq!(council.quorum, 4);
+    assert_eq!(council.request_timeout_secs, Some(240));
+    assert_eq!(council.deadline_secs, Some(900));
+    assert_eq!(council.strategy, "judge");
+
+    // Every legacy key produced a warning; nothing was dropped silently.
+    let warnings = config.warnings.join("\n");
+    for expected in
+        ["`models` was renamed to `members`", "`timeout_seconds`", "`deadline_seconds`", "`glm`"]
+    {
+        assert!(warnings.contains(expected), "missing warning about {expected}: {warnings}");
+    }
+}
+
+#[test]
+fn config_example_parses_and_named_profiles_resolve() {
+    let text =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/config.toml"))
+            .expect("config example must exist");
+    let config = Config::from_toml_str(&text).unwrap();
+
+    // The example's default profile resolves to the built-in deep council.
+    let council = config.resolve_profile(None).unwrap();
+    assert_eq!(council.name, "deep");
+    assert_eq!(council.members.len(), 5);
+
+    // User-defined named profiles resolve too.
+    let frontier = config.resolve_profile(Some("frontier")).unwrap();
+    assert_eq!(frontier.members.len(), 3);
+    let local = config.resolve_profile(Some("local")).unwrap();
+    assert_eq!(local.members.len(), 2);
+
+    assert!(config.resolve_profile(Some("nonexistent")).is_err());
+
+    // Per-adapter overrides are available as raw TOML values.
+    let claude = config.adapter_config("claude").unwrap();
+    assert_eq!(claude.get("timeout_secs").unwrap().as_integer(), Some(900));
+    let kimi = config.adapter_config("kimi").unwrap();
+    assert_eq!(kimi.get("env").unwrap().get("NO_COLOR").unwrap().as_str(), Some("1"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_argv_caps_output_and_flags_truncation() {
+    let spec = ProcessSpec::new("/bin/cat").stdin("y".repeat(10_000));
+    let limits = ProcessLimits { max_stdout_bytes: 256, ..ProcessLimits::default() };
+    let out = run_argv(&spec, &limits).await.unwrap();
+    assert!(out.truncated);
+    assert_eq!(out.stdout.len(), 256);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_argv_timeout_kills_child_promptly() {
+    let spec = ProcessSpec::new("/bin/sleep").arg("30");
+    let limits = ProcessLimits::default().with_timeout(Duration::from_millis(100));
+    let started = std::time::Instant::now();
+    let err = run_argv(&spec, &limits).await.unwrap_err();
+    assert_eq!(ProviderError::classify(&err), ErrorKind::Timeout);
+    assert!(started.elapsed() < Duration::from_secs(5));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_argv_scrubs_environment_and_applies_overrides() {
+    assert!(std::env::var_os("CARGO_MANIFEST_DIR").is_some());
+    let spec = ProcessSpec::new("/usr/bin/env");
+    let out = run_argv(&spec, &ProcessLimits::default()).await.unwrap();
+    assert!(
+        !out.stdout.lines().any(|l| l.starts_with("CARGO_MANIFEST_DIR=")),
+        "non-allowlisted variable leaked into child: {}",
+        out.stdout
+    );
+    // Allowlisted variables (e.g. PATH) survive the scrub.
+    assert!(out.stdout.lines().any(|l| l.starts_with("PATH=")), "got: {}", out.stdout);
+
+    // Explicit non-secret overrides always reach the child.
+    let spec = ProcessSpec::new("/usr/bin/env").env("CAUCUS_TEST_VAR", "override-works");
+    let out = run_argv(&spec, &ProcessLimits::default()).await.unwrap();
+    assert!(out.stdout.lines().any(|l| l == "CAUCUS_TEST_VAR=override-works"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn command_provider_end_to_end() {
+    // Arg delivery: the prompt is the final argv element.
+    let spec = CommandSpec::new("/bin/echo").args(["-n"]).prompt_delivery(PromptDelivery::Arg);
+    let provider = CommandProvider::new(spec);
+    assert_eq!(provider.complete("hello", None).await.unwrap(), "hello");
+    assert_eq!(provider.transport(), Transport::Command);
+
+    // Stdin delivery: the prompt is piped to the child.
+    let spec = CommandSpec::new("/bin/cat").prompt_delivery(PromptDelivery::Stdin);
+    let provider = CommandProvider::new(spec);
+    assert_eq!(provider.complete("ping", None).await.unwrap(), "ping");
+
+    // Provider limits bound the child process.
+    let spec = CommandSpec::new("/bin/cat").prompt_delivery(PromptDelivery::Stdin);
+    let limits = ProcessLimits { max_stdout_bytes: 128, ..ProcessLimits::default() };
+    let provider = CommandProvider::new(spec).with_limits(limits);
+    let out = provider.run(&"z".repeat(10_000)).await.unwrap();
+    assert!(out.truncated);
+    assert_eq!(out.stdout.len(), 128);
+}

--- a/crates/caucus-python/Cargo.toml
+++ b/crates/caucus-python/Cargo.toml
@@ -15,3 +15,6 @@ pyo3 = { version = "0.28", features = ["extension-module"] }
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[build-dependencies]
+pyo3-build-config = "0.28"

--- a/crates/caucus-python/build.rs
+++ b/crates/caucus-python/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Scope the macOS undefined-symbol behavior to the Python extension.
+    // Applying this as a workspace rustflag would weaken link checking for
+    // unrelated binaries such as the Caucus CLI.
+    pyo3_build_config::add_extension_module_link_args();
+}

--- a/examples/caucus.toml
+++ b/examples/caucus.toml
@@ -1,0 +1,60 @@
+# caucus configuration example (TOML).
+#
+# Load from Rust with `caucus_core::Config::load("caucus.toml")`, or pass to
+# the CLI with `--config`. Discovery order: --config, ./caucus.toml,
+# $XDG_CONFIG_HOME/caucus/config.toml, ~/.config/caucus/config.toml.
+#
+# Every member is a pinned spec: `utility:model@effort` — the model id is
+# passed to the utility verbatim (no aliasing), and effort maps to the
+# utility's native mechanism (argv for claude/codex/opencode/grok, a transient
+# non-secret child-environment override for kimi).
+
+# Profile used when none is named explicitly. Falls back to the built-in
+# "deep" profile when omitted.
+default_profile = "deep"
+
+# Per-adapter overrides, keyed by utility id (claude, codex, kimi, opencode,
+# ollama, lmstudio, gemini, grok, acp). Unknown keys are rejected.
+[adapters.claude]
+binary_path = "/usr/local/bin/claude" # absolute path; skips PATH lookup
+timeout_secs = 600                    # wall-clock limit per run; child killed on expiry
+max_stdout_bytes = 1048576            # stdout cap; excess is truncated
+max_stderr_bytes = 262144             # stderr cap; excess is truncated
+
+[adapters.kimi]
+timeout_secs = 300
+env = { NO_COLOR = "1" }             # passed only to the Kimi child process
+
+[adapters.ollama]
+# Exact model pin used by `--auto` when live discovery finds nothing.
+model = "llama3.2:latest"
+
+# The built-in "deep" profile, spelled out for reference (exact members):
+#   claude:opus@xhigh                       (stable adapter)
+#   claude:claude-fable-5@xhigh             (stable adapter)
+#   codex:default@xhigh                     (stable adapter)
+#   opencode:zai-coding-plan/glm-5.2@xhigh  (experimental adapter)
+#   kimi:kimi-code/k3@high                  (experimental adapter)
+
+# A local-only profile; no API keys required.
+[profiles.local]
+description = "Local servers only"
+members = [
+  "ollama:llama3.2:latest",
+  "lmstudio:qwen3-32b",
+]
+
+# User profiles shadow built-ins of the same name.
+[profiles.deep-custom]
+description = "Frontier CLIs at maximum effort, pinned to exact model versions"
+strategy = "judge"
+quorum = 3
+deadline_secs = 900                   # whole-run wall-clock limit
+request_timeout_secs = 300            # maximum per provider request
+members = [
+  "claude:opus@max",
+  "claude:claude-fable-5@max",
+  "codex:default@xhigh",
+  "opencode:zai-coding-plan/glm-5.2@xhigh",
+  "kimi:kimi-code/k3@max",
+]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,48 @@
+# caucus configuration example.
+#
+# Conventional location: ~/.config/caucus/config.toml
+# (or $XDG_CONFIG_HOME/caucus/config.toml).
+#
+# Member specs use the form `utility:model@effort`:
+#   utility  — adapter id: claude, codex, kimi, opencode, ollama, lmstudio,
+#              gemini, grok, acp
+#   model    — exact model id, passed through verbatim (no aliasing)
+#   effort   — optional; claude [low, medium, high, xhigh, max],
+#              codex [minimal, low, medium, high, xhigh],
+#              kimi [low, high, max], opencode [all six],
+#              grok [low, medium, high]; ollama, lmstudio, gemini, acp take none
+
+# Default profile. The built-in `deep` profile has exactly these members:
+#   claude:opus@xhigh, claude:claude-fable-5@xhigh, codex:default@xhigh,
+#   opencode:zai-coding-plan/glm-5.2@xhigh, kimi:kimi-code/k3@high
+# User profiles defined below shadow built-ins.
+default_profile = "deep"
+
+# Per-adapter overrides. Typed keys: binary_path, timeout_secs,
+# max_stdout_bytes, max_stderr_bytes, model, env. Unknown keys are rejected
+# so misspelled execution and safety settings cannot be silently ignored.
+[adapters.claude]
+timeout_secs = 900
+max_stdout_bytes = 2097152
+
+[adapters.codex]
+timeout_secs = 900
+
+[adapters.kimi]
+# binary_path = "/usr/local/bin/kimi"   # override PATH resolution
+env = { NO_COLOR = "1" }
+
+[adapters.opencode]
+# opencode/GLM compatibility is experimental.
+timeout_secs = 600
+
+# User-defined profiles.
+[profiles.local]
+members = ["ollama:llama3.2:latest", "lmstudio:qwen3-32b"]
+
+[profiles.frontier]
+members = [
+  "claude:opus@xhigh",
+  "codex:default@xhigh",
+  "kimi:kimi-code/k3@high",
+]

--- a/examples/review-receipt.md
+++ b/examples/review-receipt.md
@@ -1,0 +1,72 @@
+<!-- Example `caucus review` Markdown receipt, produced offline by a fake-adapter
+     council (`binary_path` adapter overrides pointing at a canned-response script)
+     so the structure is visible without network access. The run is capped with
+     `--max-requests 10` so the request provenance line is visible. -->
+
+# Caucus Review Receipt
+
+- Run: `bc19fe72c7d7a634`
+- Input: file (`input.rs`), 52 bytes, hash `f00dcecfd07f8450`
+- Profile: `smoke` (quorum 2, concurrency 4)
+- Requests: 7/10 used
+
+## Members
+
+- `claude:fake@high` — utility `claude`, model `fake`, effort `high`, transport `command`
+- `codex:default@high` — utility `codex`, model `default`, effort `high`, transport `command`
+- `kimi:fake@high` — utility `kimi`, model `fake`, effort `high`, transport `command`
+
+## Phase participants
+
+### review
+
+- `claude:fake@high`: ok (3 ms)
+- `codex:default@high`: ok (5 ms)
+- `kimi:fake@high`: ok (3 ms)
+
+### voting
+
+- `claude:fake@high`: ok (6 ms)
+- `codex:default@high`: ok (7 ms)
+- `kimi:fake@high`: ok (6 ms)
+
+### adjudication
+
+- `claude:fake@high`: ok (5 ms)
+
+## Findings
+
+### F1 [low] — accepted — unanimous
+
+fake finding
+
+- Evidence: fake adapter evidence
+- Source: `src-9c6821a8` (member `claude:fake@high`)
+- Adjudication: supported by the votes
+- Votes:
+  - `claude:fake@high`: support — evidence checks out
+  - `codex:default@high`: support — evidence checks out
+  - `kimi:fake@high`: support — evidence checks out
+### F2 [low] — accepted — unanimous
+
+fake finding
+
+- Evidence: fake adapter evidence
+- Source: `src-be469c5e` (member `codex:default@high`)
+- Adjudication: supported by the votes
+- Votes:
+  - `claude:fake@high`: support — evidence checks out
+  - `codex:default@high`: support — evidence checks out
+  - `kimi:fake@high`: support — evidence checks out
+
+### F3 [low] — accepted — unanimous
+
+fake finding
+
+- Evidence: fake adapter evidence
+- Source: `src-6d46ef53` (member `kimi:fake@high`)
+- Adjudication: supported by the votes
+- Votes:
+  - `claude:fake@high`: support — evidence checks out
+  - `codex:default@high`: support — evidence checks out
+  - `kimi:fake@high`: support — evidence checks out


### PR DESCRIPTION
## What changed

- Adds one provider layer for direct APIs, installed command-line subscriptions, and local model servers.
- Adds Claude, Codex, Kimi, opencode/GLM, Grok Build, Ollama, and LM Studio adapters with explicit compatibility labels.
- Adds exact-member profiles, the built-in `deep` council, `caucus doctor`, and zero-key `caucus ask --auto` discovery.
- Adds `caucus review`: independent findings, blind peer voting, evidence-linked adjudication, and Markdown or JSON decision receipts.
- Adds request caps, advisory budgets, whole-run deadlines, checkpoints, and safe resume semantics.
- Hardens provider failures, subprocess handling, consensus scoring, debate independence, Python linking, and the HTTP boundary. Browser-originated requests cannot invoke installed command or ACP adapters.
- Refreshes the README, skill, configuration examples, tests, and sample receipt.

## Why

Caucus should work with the AI subscriptions and local tools people already have, without forcing an API-key-only setup. Its review workflow should also show what the council agreed on, what it disputed, and why.

## Validation

- `cargo test --workspace --all-targets --quiet` (186 tests passed, plus the doctest)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
- README local-link check
- `sloppy analyze README.md --quiet` (pass)

## Current boundaries

- ACP is recognised in configuration but not implemented yet.
- `--budget-usd` is recorded and reported, but remains advisory until transports expose reliable cost data.
- The unauthenticated HTTP server remains a localhost development surface and rejects command and ACP transports.
