### PR TITLE
Add live debate output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ With a single model, caucus skips consensus and returns the response directly.
 
 See also: [verbose output](examples/verbose.md), [debate with supreme-court format](examples/debate-supreme-court.md)
 
+To watch a debate as it happens, add `--live`. Initial positions are shown
+before the first round, then each model's full round response is written to
+stderr as soon as it is ready. The final result remains on stdout. Use
+`--format plain` to avoid replaying the transcript after the live output.
+
+```bash
+caucus debate "The gold price will increase over the next 12 months" \
+  --rounds 3 --live --format plain
+```
+
 ## CLI commands
 
 ```bash
@@ -91,7 +101,7 @@ caucus ask "prompt" --profile deep          # council profile (exact members)
 caucus ask "prompt" --auto                  # ready subscription CLIs + local models
 caucus review --git-diff                    # adjudicated multi-model code review
 caucus compare "prompt" --strategies majority-vote,judge
-caucus debate "prompt" --rounds 3
+caucus debate "prompt" --rounds 3 --live
 caucus bench tests.jsonl -o results.json
 caucus profiles                             # list built-in and user profiles
 caucus doctor                               # adapter readiness + config health

--- a/SKILL.md
+++ b/SKILL.md
@@ -54,6 +54,7 @@ Always use `-f json` for parseable output.
 caucus "prompt" -f json                                          # all models, judge strategy
 caucus "prompt" -m gpt-5.2,claude-opus-4-6 -f json              # specific models
 caucus "prompt" -s debate -f json                                # debate strategy
+caucus debate "prompt" --rounds 3 --live --format plain          # stream the debate live
 caucus "prompt" --profile deep -f json                           # council profile (exact members)
 caucus "prompt" --auto -f json                                   # zero-key council, no API keys
 caucus compare "prompt" --strategies majority-vote,judge -f json # compare strategies

--- a/crates/caucus-cli/src/commands/debate.rs
+++ b/crates/caucus-cli/src/commands/debate.rs
@@ -1,5 +1,9 @@
+use std::io::Write;
+
 use caucus_core::strategy::debate::DebateConfig;
-use caucus_core::{Candidate, ConsensusStrategy, FanoutConfig, MultiRoundDebate, OutputFormat};
+use caucus_core::{
+    Candidate, ConsensusStrategy, DebateEvent, FanoutConfig, MultiRoundDebate, OutputFormat,
+};
 use clap::Args;
 use colored::Colorize;
 
@@ -17,6 +21,10 @@ pub struct DebateArgs {
     /// Number of debate rounds
     #[arg(short, long, default_value = "3", value_parser = super::parse_rounds)]
     pub rounds: usize,
+
+    /// Stream initial positions and each completed round response to stderr
+    #[arg(long)]
+    pub live: bool,
 
     /// Output format
     #[arg(short, long, default_value = "detailed",
@@ -82,8 +90,18 @@ pub async fn run(args: DebateArgs) -> anyhow::Result<()> {
         max_rounds: args.rounds,
         ..Default::default()
     });
-
-    let result = strategy.resolve_multi(&candidates, Some(judge_llm), Some(&provider)).await?;
+    let result = if args.live {
+        strategy
+            .resolve_multi_observed(
+                &candidates,
+                Some(judge_llm),
+                Some(&provider),
+                &print_live_event,
+            )
+            .await?
+    } else {
+        strategy.resolve_multi(&candidates, Some(judge_llm), Some(&provider)).await?
+    };
 
     eprintln!(
         "\n{} Debate concluded (agreement: {:.0}%)\n",
@@ -94,4 +112,88 @@ pub async fn run(args: DebateArgs) -> anyhow::Result<()> {
     println!("{}", format.render(&result));
 
     Ok(())
+}
+
+fn participant_label(participant: usize, model: Option<&str>) -> String {
+    model.map(str::to_string).unwrap_or_else(|| format!("participant {}", participant + 1))
+}
+
+fn render_live_event(event: &DebateEvent) -> String {
+    match event {
+        DebateEvent::InitialPosition { participant, model, content } => format!(
+            "── Initial position · {} ──\n{}",
+            participant_label(*participant, model.as_deref()),
+            content
+        ),
+        DebateEvent::RoundStarted { round, max_rounds } => {
+            format!("▶ Round {round}/{max_rounds}")
+        }
+        DebateEvent::PositionRevised { round, participant, model, response, .. } => format!(
+            "── Round {round} · {} ──\n{}",
+            participant_label(*participant, model.as_deref()),
+            response
+        ),
+        DebateEvent::PositionRetained { round, participant, model, reason } => format!(
+            "✗ Round {round} · {} kept its previous position ({reason})",
+            participant_label(*participant, model.as_deref())
+        ),
+        DebateEvent::RoundCompleted { round, mean_similarity: Some(similarity) } => {
+            format!(
+                "✓ Round {round} complete (mean position similarity: {:.0}%)",
+                similarity * 100.0
+            )
+        }
+        DebateEvent::RoundCompleted { round, mean_similarity: None } => {
+            format!("✓ Round {round} complete (no successful revisions)")
+        }
+        DebateEvent::Converged { round, mean_similarity } => format!(
+            "✓ Debate converged after round {round} ({:.0}% similarity)",
+            mean_similarity * 100.0
+        ),
+        DebateEvent::AdjudicationStarted => "▶ Adjudicating final positions".to_string(),
+    }
+}
+
+fn print_live_event(event: &DebateEvent) {
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(stderr, "\n{}", render_live_event(event));
+    let _ = stderr.flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: DebateArgs,
+    }
+
+    #[test]
+    fn live_flag_is_opt_in() {
+        let normal = TestCli::try_parse_from(["test", "topic"]).unwrap();
+        assert!(!normal.args.live);
+
+        let live = TestCli::try_parse_from(["test", "topic", "--live"]).unwrap();
+        assert!(live.args.live);
+        assert_eq!(live.args.format, "detailed");
+    }
+
+    #[test]
+    fn live_revision_includes_model_round_and_full_response() {
+        let rendered = render_live_event(&DebateEvent::PositionRevised {
+            round: 2,
+            participant: 0,
+            model: Some("claude-opus".to_string()),
+            response: "Critique first.\nFINAL ANSWER: Revised view.".to_string(),
+            position: "Revised view.".to_string(),
+        });
+
+        assert!(rendered.contains("Round 2 · claude-opus"));
+        assert!(rendered.contains("Critique first."));
+        assert!(rendered.contains("FINAL ANSWER: Revised view."));
+    }
 }

--- a/crates/caucus-core/src/lib.rs
+++ b/crates/caucus-core/src/lib.rs
@@ -59,6 +59,6 @@ pub use types::{
 
 pub use format::OutputFormat;
 pub use strategy::{
-    DebateThenVote, JudgeSynthesis, MajorityVote, MultiRoundDebate, SemanticClustering,
-    WeightedVote,
+    DebateEvent, DebateThenVote, JudgeSynthesis, MajorityVote, MultiRoundDebate,
+    SemanticClustering, WeightedVote,
 };

--- a/crates/caucus-core/src/strategy/debate.rs
+++ b/crates/caucus-core/src/strategy/debate.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::future::join_all;
+use futures::stream::{FuturesUnordered, StreamExt};
 
 use crate::provider::MultiProvider;
 use crate::strategy::judge::{DEFAULT_JUDGE_SYSTEM, parse_judge_response};
@@ -21,6 +21,53 @@ pub struct MultiRoundDebate {
     pub config: DebateConfig,
 }
 
+/// A progress event emitted while a multi-round debate is running.
+///
+/// Observers are notified synchronously, so handlers should render or enqueue
+/// the event quickly rather than doing blocking work.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DebateEvent {
+    InitialPosition {
+        participant: usize,
+        model: Option<String>,
+        content: String,
+    },
+    RoundStarted {
+        round: usize,
+        max_rounds: usize,
+    },
+    PositionRevised {
+        round: usize,
+        participant: usize,
+        model: Option<String>,
+        /// The participant's full response, including its critique when present.
+        response: String,
+        /// The standalone position retained for the next round.
+        position: String,
+    },
+    PositionRetained {
+        round: usize,
+        participant: usize,
+        model: Option<String>,
+        reason: String,
+    },
+    RoundCompleted {
+        round: usize,
+        mean_similarity: Option<f64>,
+    },
+    Converged {
+        round: usize,
+        mean_similarity: f64,
+    },
+    AdjudicationStarted,
+}
+
+fn emit(observer: Option<&(dyn Fn(&DebateEvent) + Send + Sync)>, event: DebateEvent) {
+    if let Some(observer) = observer {
+        observer(&event);
+    }
+}
+
 pub struct DebateConfig {
     /// Maximum number of debate rounds.
     pub max_rounds: usize,
@@ -28,6 +75,13 @@ pub struct DebateConfig {
     pub convergence_threshold: f64,
     /// System prompt for debate participants.
     pub system_prompt: String,
+}
+
+struct DebateRun<'a> {
+    rounds_completed: usize,
+    round_history: Vec<Vec<String>>,
+    warnings: Vec<String>,
+    observer: Option<&'a (dyn Fn(&DebateEvent) + Send + Sync)>,
 }
 
 impl Default for DebateConfig {
@@ -114,6 +168,29 @@ impl MultiRoundDebate {
         participant_llms: &[&dyn LlmProvider],
         judge: &dyn LlmProvider,
     ) -> Result<ConsensusResult> {
+        self.resolve_with_participants_inner(candidates, participant_llms, judge, None).await
+    }
+
+    /// Run with an observer that receives progress events in completion order.
+    /// The observer runs on the debate task and should return promptly.
+    pub async fn resolve_with_participants_observed(
+        &self,
+        candidates: &[Candidate],
+        participant_llms: &[&dyn LlmProvider],
+        judge: &dyn LlmProvider,
+        observer: &(dyn Fn(&DebateEvent) + Send + Sync),
+    ) -> Result<ConsensusResult> {
+        self.resolve_with_participants_inner(candidates, participant_llms, judge, Some(observer))
+            .await
+    }
+
+    async fn resolve_with_participants_inner(
+        &self,
+        candidates: &[Candidate],
+        participant_llms: &[&dyn LlmProvider],
+        judge: &dyn LlmProvider,
+        observer: Option<&(dyn Fn(&DebateEvent) + Send + Sync)>,
+    ) -> Result<ConsensusResult> {
         if candidates.is_empty() {
             anyhow::bail!("No candidates provided");
         }
@@ -138,15 +215,28 @@ impl MultiRoundDebate {
         let mut round_history: Vec<Vec<String>> = vec![current_positions.clone()];
         let mut warnings = Vec::new();
 
+        for (participant, candidate) in candidates.iter().enumerate() {
+            emit(
+                observer,
+                DebateEvent::InitialPosition {
+                    participant,
+                    model: candidate.model.clone(),
+                    content: candidate.content.clone(),
+                },
+            );
+        }
+
         let mut actual_rounds = 0;
         for round in 1..=self.config.max_rounds {
             actual_rounds = round;
+            emit(observer, DebateEvent::RoundStarted { round, max_rounds: self.config.max_rounds });
 
             // Each participant independently blind-critiques the shuffled,
-            // anonymized positions and revises only its own. `join_all` polls
-            // borrowed provider futures concurrently without requiring the
-            // `'static` lifetime that spawned tasks would need.
-            let attempts = participant_llms.iter().enumerate().map(|(i, llm)| {
+            // anonymized positions and revises only its own. Futures are
+            // consumed in completion order so observers can render each
+            // response immediately without waiting for the slowest member.
+            let mut attempts = FuturesUnordered::new();
+            for (i, llm) in participant_llms.iter().enumerate() {
                 let prompt = blind_critique_prompt(
                     question,
                     &current_positions,
@@ -154,42 +244,70 @@ impl MultiRoundDebate {
                     round,
                     self.config.max_rounds,
                 );
-                async move {
+                attempts.push(async move {
                     let result = tokio::time::timeout(
                         llm.options().timeout,
                         llm.complete(&prompt, Some(&self.config.system_prompt)),
                     )
                     .await;
                     (i, result)
-                }
-            });
-            let mut new_positions = Vec::with_capacity(current_positions.len());
+                });
+            }
+            let mut new_positions = current_positions.clone();
             let mut refined_indices = Vec::with_capacity(current_positions.len());
-            for (i, result) in join_all(attempts).await {
+            while let Some((i, result)) = attempts.next().await {
+                let model = candidates[i].model.clone();
                 match result {
                     Ok(Ok(refined)) => {
-                        let refined = extract_final_answer(&refined);
-                        if refined.trim().is_empty() {
+                        let position = extract_final_answer(&refined);
+                        if position.trim().is_empty() {
+                            let reason = "returned an empty refinement".to_string();
                             warnings.push(format!(
-                                "debate round {round}: participant {i} returned an empty refinement; retained its previous position"
+                                "debate round {round}: participant {i} {reason}; retained its previous position"
                             ));
-                            new_positions.push(current_positions[i].clone());
+                            emit(
+                                observer,
+                                DebateEvent::PositionRetained {
+                                    round,
+                                    participant: i,
+                                    model,
+                                    reason,
+                                },
+                            );
                         } else {
                             refined_indices.push(i);
-                            new_positions.push(refined);
+                            new_positions[i] = position.clone();
+                            emit(
+                                observer,
+                                DebateEvent::PositionRevised {
+                                    round,
+                                    participant: i,
+                                    model,
+                                    response: refined,
+                                    position,
+                                },
+                            );
                         }
                     }
                     Ok(Err(error)) => {
+                        let reason = format!("failed: {error}");
                         warnings.push(format!(
                             "debate round {round}: participant {i} failed ({error}); retained its previous position"
                         ));
-                        new_positions.push(current_positions[i].clone());
+                        emit(
+                            observer,
+                            DebateEvent::PositionRetained { round, participant: i, model, reason },
+                        );
                     }
                     Err(_) => {
+                        let reason = "exceeded its request timeout".to_string();
                         warnings.push(format!(
                             "debate round {round}: participant {i} exceeded its request timeout; retained its previous position"
                         ));
-                        new_positions.push(current_positions[i].clone());
+                        emit(
+                            observer,
+                            DebateEvent::PositionRetained { round, participant: i, model, reason },
+                        );
                     }
                 }
             }
@@ -206,23 +324,29 @@ impl MultiRoundDebate {
 
             current_positions = new_positions;
             round_history.push(current_positions.clone());
+            emit(observer, DebateEvent::RoundCompleted { round, mean_similarity });
 
             if let Some(mean_similarity) = mean_similarity {
-                tracing::info!(
-                    "Debate round {}/{} complete (mean successful-position similarity: {:.3})",
-                    round,
-                    self.config.max_rounds,
-                    mean_similarity
-                );
-                if mean_similarity >= self.config.convergence_threshold {
+                if observer.is_none() {
                     tracing::info!(
-                        "Debate converged early at round {} (threshold: {:.2})",
+                        "Debate round {}/{} complete (mean successful-position similarity: {:.3})",
                         round,
-                        self.config.convergence_threshold
+                        self.config.max_rounds,
+                        mean_similarity
                     );
+                }
+                if mean_similarity >= self.config.convergence_threshold {
+                    emit(observer, DebateEvent::Converged { round, mean_similarity });
+                    if observer.is_none() {
+                        tracing::info!(
+                            "Debate converged early at round {} (threshold: {:.2})",
+                            round,
+                            self.config.convergence_threshold
+                        );
+                    }
                     break;
                 }
-            } else {
+            } else if observer.is_none() {
                 tracing::warn!(
                     "Debate round {}/{} had no successful refinements; convergence not evaluated",
                     round,
@@ -235,9 +359,7 @@ impl MultiRoundDebate {
             candidates,
             &current_positions,
             judge,
-            actual_rounds,
-            round_history,
-            warnings,
+            DebateRun { rounds_completed: actual_rounds, round_history, warnings, observer },
         )
         .await
     }
@@ -250,10 +372,9 @@ impl MultiRoundDebate {
         candidates: &[Candidate],
         final_positions: &[String],
         judge: &dyn LlmProvider,
-        actual_rounds: usize,
-        round_history: Vec<Vec<String>>,
-        mut warnings: Vec<String>,
+        run: DebateRun<'_>,
     ) -> Result<ConsensusResult> {
+        let DebateRun { rounds_completed, round_history, mut warnings, observer } = run;
         let positions_text = final_positions
             .iter()
             .enumerate()
@@ -265,10 +386,11 @@ impl MultiRoundDebate {
             .replace("{count}", &final_positions.len().to_string())
             .replace("{candidates}", &positions_text);
 
+        emit(observer, DebateEvent::AdjudicationStarted);
         let judge_response = judge.complete(&judge_prompt, Some(DEFAULT_JUDGE_SYSTEM)).await?;
 
         let mut metadata = HashMap::new();
-        metadata.insert("rounds_completed".to_string(), serde_json::json!(actual_rounds));
+        metadata.insert("rounds_completed".to_string(), serde_json::json!(rounds_completed));
         metadata.insert("round_history".to_string(), serde_json::json!(round_history));
         metadata.insert("blind".to_string(), serde_json::json!(true));
 
@@ -339,7 +461,7 @@ impl MultiRoundDebate {
             dissents,
             reasoning: Some(format!(
                 "{reasoning} (debate completed in {} round(s) of {} maximum)",
-                actual_rounds, self.config.max_rounds,
+                rounds_completed, self.config.max_rounds,
             )),
             metadata,
         })
@@ -349,6 +471,42 @@ impl MultiRoundDebate {
 impl Default for MultiRoundDebate {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl MultiRoundDebate {
+    /// Run a multi-provider debate while reporting progress in completion
+    /// order to `observer`.
+    pub async fn resolve_multi_observed(
+        &self,
+        candidates: &[Candidate],
+        llm: Option<&dyn LlmProvider>,
+        participants: Option<&MultiProvider>,
+        observer: &(dyn Fn(&DebateEvent) + Send + Sync),
+    ) -> Result<ConsensusResult> {
+        self.resolve_multi_inner(candidates, llm, participants, Some(observer)).await
+    }
+
+    async fn resolve_multi_inner(
+        &self,
+        candidates: &[Candidate],
+        llm: Option<&dyn LlmProvider>,
+        participants: Option<&MultiProvider>,
+        observer: Option<&(dyn Fn(&DebateEvent) + Send + Sync)>,
+    ) -> Result<ConsensusResult> {
+        let judge =
+            llm.ok_or_else(|| anyhow::anyhow!("MultiRoundDebate requires an LLM provider"))?;
+
+        let mut participant_llms: Vec<&dyn LlmProvider> = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            let own = candidate
+                .model
+                .as_deref()
+                .and_then(|model| participants.and_then(|providers| providers.get(model)));
+            participant_llms.push(own.unwrap_or(judge));
+        }
+
+        self.resolve_with_participants_inner(candidates, &participant_llms, judge, observer).await
     }
 }
 
@@ -479,16 +637,7 @@ impl ConsensusStrategy for MultiRoundDebate {
         llm: Option<&dyn LlmProvider>,
         participants: Option<&MultiProvider>,
     ) -> Result<ConsensusResult> {
-        let judge =
-            llm.ok_or_else(|| anyhow::anyhow!("MultiRoundDebate requires an LLM provider"))?;
-
-        let mut participant_llms: Vec<&dyn LlmProvider> = Vec::with_capacity(candidates.len());
-        for c in candidates {
-            let own = c.model.as_deref().and_then(|m| participants.and_then(|p| p.get(m)));
-            participant_llms.push(own.unwrap_or(judge));
-        }
-
-        self.resolve_with_participants(candidates, &participant_llms, judge).await
+        self.resolve_multi_inner(candidates, llm, participants, None).await
     }
 }
 
@@ -496,6 +645,19 @@ impl ConsensusStrategy for MultiRoundDebate {
 mod tests {
     use super::*;
     use crate::provider::MockProvider;
+
+    struct DelayedProvider {
+        delay: std::time::Duration,
+        response: String,
+    }
+
+    #[async_trait]
+    impl LlmProvider for DelayedProvider {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+            tokio::time::sleep(self.delay).await;
+            Ok(self.response.clone())
+        }
+    }
 
     struct FailingProvider;
 
@@ -565,6 +727,67 @@ mod tests {
         let last = history.last().unwrap().as_array().unwrap();
         let positions: Vec<&str> = last.iter().filter_map(|p| p.as_str()).collect();
         assert_eq!(positions, vec!["From provider one", "From provider two"]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn observer_receives_each_revision_in_completion_order() {
+        let fast = DelayedProvider {
+            delay: std::time::Duration::from_millis(5),
+            response: "Fast critique.\nFINAL ANSWER: Fast revision".to_string(),
+        };
+        let slow = DelayedProvider {
+            delay: std::time::Duration::from_millis(200),
+            response: "Slow critique.\nFINAL ANSWER: Slow revision".to_string(),
+        };
+        let judge = MockProvider::fixed(judge_json(0.7));
+        let candidates = vec![
+            Candidate::new("Initial fast").with_model("fast-model"),
+            Candidate::new("Initial slow").with_model("slow-model"),
+        ];
+        let participants: Vec<&dyn LlmProvider> = vec![&fast, &slow];
+        let (sender, mut events) = tokio::sync::mpsc::unbounded_channel();
+        let observer = move |event: &DebateEvent| {
+            let _ = sender.send(event.clone());
+        };
+        let strategy = MultiRoundDebate::new().with_rounds(1);
+
+        let mut run = Box::pin(strategy.resolve_with_participants_observed(
+            &candidates,
+            &participants,
+            &judge,
+            &observer,
+        ));
+        let first_revision = tokio::time::timeout(std::time::Duration::from_millis(100), async {
+            loop {
+                tokio::select! {
+                    event = events.recv() => {
+                        if let DebateEvent::PositionRevised { model, response, .. } =
+                            event.expect("observer remains connected")
+                        {
+                            break (model, response);
+                        }
+                    }
+                    _ = &mut run => panic!("debate completed before the first revision event"),
+                }
+            }
+        })
+        .await
+        .expect("fast revision should be observable before the slow participant completes");
+
+        assert_eq!(first_revision.0.as_deref(), Some("fast-model"));
+        assert!(first_revision.1.contains("Fast critique."));
+
+        let result = run.await.unwrap();
+        let final_positions = result.metadata["round_history"].as_array().unwrap().last().unwrap();
+        assert_eq!(final_positions[0], serde_json::json!("Fast revision"));
+        assert_eq!(final_positions[1], serde_json::json!("Slow revision"));
+
+        let remaining: Vec<DebateEvent> = std::iter::from_fn(|| events.try_recv().ok()).collect();
+        assert!(remaining.iter().any(|event| matches!(
+            event,
+            DebateEvent::PositionRevised { model: Some(model), .. } if model == "slow-model"
+        )));
+        assert!(remaining.iter().any(|event| matches!(event, DebateEvent::AdjudicationStarted)));
     }
 
     #[tokio::test]

--- a/crates/caucus-core/src/strategy/mod.rs
+++ b/crates/caucus-core/src/strategy/mod.rs
@@ -4,7 +4,7 @@ pub mod judge;
 pub mod semantic;
 pub mod vote;
 
-pub use debate::MultiRoundDebate;
+pub use debate::{DebateEvent, MultiRoundDebate};
 pub use hybrid::DebateThenVote;
 pub use judge::JudgeSynthesis;
 pub use semantic::SemanticClustering;


### PR DESCRIPTION
## What changed

- Adds `caucus debate --live`.
- Prints initial positions before round one, then prints each model's full critique and revised answer as soon as that model finishes.
- Sends live progress to stderr so plain and JSON results on stdout remain safe to pipe.
- Adds typed core debate events and additive observed-run APIs without changing the existing `MultiRoundDebate` struct or normal execution methods.
- Processes concurrent round responses in completion order while preserving participant order in the final transcript.
- Documents the live workflow and the `--format plain` option for avoiding a final transcript replay.

## Why

The detailed format already retained the debate transcript, but only displayed it after adjudication. A multi-round debate could therefore look idle for several minutes. Live mode makes the deliberation visible while it happens without changing the final result format.

## Validation

- `cargo test --workspace --all-targets --quiet` (189 tests passed)
- `cargo test --doc --workspace --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
- `sloppy analyze README.md --quiet`
- End-to-end mock debate using `--live --format plain`
