### PR TITLE
Format doctor output and expand deep profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ claude:claude-fable-5@xhigh
 codex:default@xhigh
 opencode:zai-coding-plan/glm-5.2@xhigh
 kimi:kimi-code/k3@high
+grok:grok-4.5@high
 ```
 
 Adapter compatibility labels, shown by `caucus doctor`:
@@ -136,7 +137,7 @@ Adapter compatibility labels, shown by `caucus doctor`:
 | `experimental` | kimi, opencode, gemini, grok, acp | Works, but flags/pins may shift |
 
 ```bash
-caucus doctor          # readiness, config validity, profile health (or --json)
+caucus doctor          # Markdown readiness tables (or --json)
 caucus profiles        # all profiles with resolved members (or a name, or --json)
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,7 +86,7 @@ classifications. `--max-requests` is a hard cap; `--budget-usd` is advisory.
 ### 2b. Inspect Councils
 
 ```bash
-caucus doctor          # adapter readiness + config health (--json available)
+caucus doctor          # Markdown readiness tables (--json available)
 caucus profiles        # list profiles and exact members (or a name / --json)
 ```
 
@@ -94,7 +94,7 @@ Adapters are labeled `stable` (claude, codex, ollama, lmstudio) or
 `experimental` (kimi, opencode, gemini, grok, acp). The built-in `deep`
 profile: `claude:opus@xhigh`, `claude:claude-fable-5@xhigh`,
 `codex:default@xhigh`, `opencode:zai-coding-plan/glm-5.2@xhigh`,
-`kimi:kimi-code/k3@high`.
+`kimi:kimi-code/k3@high`, `grok:grok-4.5@high`.
 
 Profile `deadline_secs` is a whole-run wall-clock limit;
 `request_timeout_secs` bounds each provider request independently. Adapter

--- a/crates/caucus-cli/src/commands/council.rs
+++ b/crates/caucus-cli/src/commands/council.rs
@@ -36,11 +36,27 @@ pub const AUTO_EFFORT: &str = "high";
 /// order. Returns `(None, Config::default())` when no file exists. Legacy
 /// schema migration warnings are surfaced on stderr.
 pub fn load_config(explicit: Option<&Path>) -> anyhow::Result<(Option<PathBuf>, Config)> {
+    load_config_with_warnings(explicit, true)
+}
+
+/// Load configuration without printing migration warnings. Commands that
+/// render a structured diagnostic report can surface `Config::warnings`
+/// themselves instead of mixing unformatted stderr into their output.
+pub fn load_config_quiet(explicit: Option<&Path>) -> anyhow::Result<(Option<PathBuf>, Config)> {
+    load_config_with_warnings(explicit, false)
+}
+
+fn load_config_with_warnings(
+    explicit: Option<&Path>,
+    print_warnings: bool,
+) -> anyhow::Result<(Option<PathBuf>, Config)> {
     match Config::discover(explicit)? {
         Some((path, config)) => {
             validate_adapter_configs(&config)?;
-            for warning in &config.warnings {
-                eprintln!("config warning: {warning}");
+            if print_warnings {
+                for warning in &config.warnings {
+                    eprintln!("config warning: {warning}");
+                }
             }
             Ok((Some(path), config))
         }

--- a/crates/caucus-cli/src/commands/doctor.rs
+++ b/crates/caucus-cli/src/commands/doctor.rs
@@ -2,12 +2,12 @@
 //! health. Probes the local machine only — never reads credentials.
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use caucus_core::adapters::{self, AdapterDescriptor, Readiness};
 use caucus_core::{Config, Transport, builtin_profiles};
 use clap::Args;
-use colored::Colorize;
 
 use super::council;
 
@@ -140,13 +140,123 @@ async fn report(config_path: Option<PathBuf>, config: &Config) -> serde_json::Va
     })
 }
 
+fn markdown_cell(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('|', "\\|").replace(['\r', '\n'], "<br>")
+}
+
+fn render_markdown(report: &serde_json::Value) -> String {
+    let mut output = String::new();
+    let config = &report["config"];
+    let valid = config["valid"].as_bool() == Some(true);
+    let path = config["path"].as_str().unwrap_or(if valid {
+        "none found (using defaults + built-ins)"
+    } else {
+        "discovery failed"
+    });
+    let status = if valid {
+        "✓ Valid".to_string()
+    } else {
+        format!("✗ {}", config["error"].as_str().unwrap_or("invalid"))
+    };
+    let default_profile = config["default_profile"].as_str().unwrap_or("none");
+
+    writeln!(output, "## Config\n").unwrap();
+    writeln!(output, "| Field | Value |").unwrap();
+    writeln!(output, "| :--- | :--- |").unwrap();
+    writeln!(output, "| Path | {} |", markdown_cell(path)).unwrap();
+    writeln!(output, "| Status | {} |", markdown_cell(&status)).unwrap();
+    writeln!(output, "| Default profile | {} |", markdown_cell(default_profile)).unwrap();
+    writeln!(output, "| User profiles | {} |", config["user_profiles"]).unwrap();
+    writeln!(output, "| Built-in profiles | {} |", config["builtin_profiles"]).unwrap();
+
+    if let Some(warnings) = config["warnings"].as_array()
+        && !warnings.is_empty()
+    {
+        writeln!(output, "\n## Config warnings\n").unwrap();
+        writeln!(output, "| Warning |").unwrap();
+        writeln!(output, "| :--- |").unwrap();
+        for warning in warnings.iter().filter_map(|value| value.as_str()) {
+            writeln!(output, "| {} |", markdown_cell(warning)).unwrap();
+        }
+    }
+
+    writeln!(output, "\n## Adapters\n").unwrap();
+    writeln!(output, "| Adapter | Transport | Stability | Status | Efforts | Notes |").unwrap();
+    writeln!(output, "| :--- | :--- | :--- | :--- | :--- | :--- |").unwrap();
+    for row in report["adapters"].as_array().into_iter().flatten() {
+        let ready = row["ready"].as_bool().unwrap_or(false);
+        let readiness = row["readiness"].as_str().unwrap_or("");
+        let status = format!("{} {readiness}", if ready { "✓" } else { "✗" });
+        let efforts = row["efforts"]
+            .as_array()
+            .map(|items| {
+                if items.is_empty() {
+                    "none".to_string()
+                } else {
+                    items.iter().filter_map(|item| item.as_str()).collect::<Vec<_>>().join(", ")
+                }
+            })
+            .unwrap_or_else(|| "none".to_string());
+        writeln!(
+            output,
+            "| {} | {} | {} | {} | {} | {} |",
+            markdown_cell(row["id"].as_str().unwrap_or("")),
+            markdown_cell(row["transport"].as_str().unwrap_or("")),
+            markdown_cell(row["stability"].as_str().unwrap_or("")),
+            markdown_cell(&status),
+            markdown_cell(&efforts),
+            markdown_cell(row["notes"].as_str().unwrap_or("")),
+        )
+        .unwrap();
+    }
+
+    writeln!(output, "\n## Profiles\n").unwrap();
+    writeln!(output, "| Profile | Source | Strategy | Status | Ready | Quorum |").unwrap();
+    writeln!(output, "| :--- | :--- | :--- | :--- | ---: | ---: |").unwrap();
+    for row in report["profiles"].as_array().into_iter().flatten() {
+        let usable = row["usable"].as_bool().unwrap_or(false);
+        let status = if usable { "✓ usable" } else { "✗ unavailable" };
+        let source = if row["builtin"].as_bool() == Some(true) { "built-in" } else { "user" };
+        writeln!(
+            output,
+            "| {} | {source} | {} | {status} | {} / {} | {} |",
+            markdown_cell(row["name"].as_str().unwrap_or("")),
+            markdown_cell(row["strategy"].as_str().unwrap_or("")),
+            row["ready_members"],
+            row["members"],
+            row["quorum"],
+        )
+        .unwrap();
+    }
+
+    let summary = &report["summary"];
+    writeln!(output, "\n## Summary\n").unwrap();
+    writeln!(output, "| Metric | Ready | Total |").unwrap();
+    writeln!(output, "| :--- | ---: | ---: |").unwrap();
+    writeln!(
+        output,
+        "| Adapters | {} | {} |",
+        summary["adapters_ready"], summary["adapters_total"]
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "| Profiles | {} | {} |",
+        summary["profiles_usable"], summary["profiles_total"]
+    )
+    .unwrap();
+
+    output
+}
+
 pub async fn run(args: DoctorArgs) -> anyhow::Result<()> {
     // An explicit-but-invalid config is reported, not fatal: doctor exists to
     // surface exactly that kind of problem.
-    let (config_path, config, config_error) = match council::load_config(args.config.as_deref()) {
-        Ok((path, config)) => (path, config, None),
-        Err(e) => (args.config.clone(), Config::default(), Some(e.to_string())),
-    };
+    let (config_path, config, config_error) =
+        match council::load_config_quiet(args.config.as_deref()) {
+            Ok((path, config)) => (path, config, None),
+            Err(e) => (args.config.clone(), Config::default(), Some(e.to_string())),
+        };
 
     let mut report = report(config_path, &config).await;
     if let Some(error) = &config_error {
@@ -159,73 +269,7 @@ pub async fn run(args: DoctorArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Human-readable rendering.
-    let config = &report["config"];
-    let valid = config["valid"].as_bool() == Some(true);
-    match (&config["path"], valid) {
-        (serde_json::Value::String(path), _) => println!("{} {path}", "Config:".bold()),
-        (_, true) => println!("{} none found (using defaults + built-ins)", "Config:".bold()),
-        (_, false) => println!("{} discovery failed", "Config:".bold()),
-    }
-    if valid {
-        let default = config["default_profile"].as_str().unwrap_or("none");
-        println!(
-            "  valid; default profile: {default}; user profiles: {}; built-ins: {}",
-            config["user_profiles"], config["builtin_profiles"]
-        );
-    } else {
-        println!("  {} {}", "✗".red(), config["error"].as_str().unwrap_or("invalid"));
-    }
-
-    println!("\n{}", "Adapters:".bold());
-    for row in report["adapters"].as_array().into_iter().flatten() {
-        let ready = row["ready"].as_bool().unwrap_or(false);
-        let mark = if ready { "✓".green() } else { "✗".red() };
-        let efforts = row["efforts"]
-            .as_array()
-            .map(|e| {
-                if e.is_empty() {
-                    "none".to_string()
-                } else {
-                    e.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(", ")
-                }
-            })
-            .unwrap_or_else(|| "none".to_string());
-        println!(
-            "  {mark} {:<9} {:<12} {:<12} {}",
-            row["id"].as_str().unwrap_or(""),
-            row["transport"].as_str().unwrap_or(""),
-            row["stability"].as_str().unwrap_or(""),
-            row["readiness"].as_str().unwrap_or(""),
-        );
-        println!("      efforts: {efforts}; {}", row["notes"].as_str().unwrap_or(""));
-    }
-
-    println!("\n{}", "Profiles:".bold());
-    for row in report["profiles"].as_array().into_iter().flatten() {
-        let usable = row["usable"].as_bool().unwrap_or(false);
-        let mark = if usable { "✓".green() } else { "✗".yellow() };
-        let kind = if row["builtin"].as_bool() == Some(true) { "built-in" } else { "user" };
-        println!(
-            "  {mark} {:<16} {:<8} strategy={} quorum={} ready={}/{}",
-            row["name"].as_str().unwrap_or(""),
-            kind,
-            row["strategy"].as_str().unwrap_or(""),
-            row["quorum"],
-            row["ready_members"],
-            row["members"],
-        );
-    }
-
-    let summary = &report["summary"];
-    println!(
-        "\n{} {}/{} adapters ready, {}/{} profiles usable",
-        "Summary:".bold(),
-        summary["adapters_ready"],
-        summary["adapters_total"],
-        summary["profiles_usable"],
-        summary["profiles_total"],
-    );
+    print!("{}", render_markdown(&report));
     Ok(())
 }
 
@@ -281,5 +325,55 @@ members = ["codex:default@high"]
         let config = Config::default();
         let rows = profile_rows(&config, &BTreeMap::new());
         assert!(rows.iter().any(|r| r.name == "deep"));
+    }
+
+    #[test]
+    fn markdown_report_uses_tables_and_escapes_cells() {
+        let report = serde_json::json!({
+            "config": {
+                "path": "/tmp/caucus.toml",
+                "valid": true,
+                "default_profile": "deep",
+                "user_profiles": 1,
+                "builtin_profiles": 1,
+                "warnings": ["old | key"],
+            },
+            "adapters": [{
+                "id": "claude",
+                "transport": "command",
+                "stability": "stable",
+                "ready": true,
+                "readiness": "ready",
+                "efforts": ["high", "xhigh"],
+                "notes": "native | CLI",
+            }],
+            "profiles": [{
+                "name": "deep",
+                "builtin": false,
+                "strategy": "judge",
+                "quorum": 1,
+                "members": 1,
+                "ready_members": 1,
+                "usable": true,
+            }],
+            "summary": {
+                "adapters_ready": 1,
+                "adapters_total": 1,
+                "profiles_usable": 1,
+                "profiles_total": 1,
+            },
+        });
+
+        let rendered = render_markdown(&report);
+        assert!(
+            rendered.contains("| Adapter | Transport | Stability | Status | Efforts | Notes |")
+        );
+        assert!(
+            rendered
+                .contains("| claude | command | stable | ✓ ready | high, xhigh | native \\| CLI |")
+        );
+        assert!(rendered.contains("| old \\| key |"));
+        assert!(rendered.contains("| deep | user | judge | ✓ usable | 1 / 1 | 1 |"));
+        assert!(rendered.contains("| Adapters | 1 | 1 |"));
     }
 }

--- a/crates/caucus-cli/src/commands/profiles.rs
+++ b/crates/caucus-cli/src/commands/profiles.rs
@@ -154,8 +154,9 @@ members = ["claude:claude-opus-4-6@xhigh", "kimi:kimi-code/k3@high"]
         // Built-in deep is present with its exact pins.
         let deep = all.iter().find(|e| e.name == "deep").unwrap();
         assert!(deep.builtin);
-        assert_eq!(deep.members.len(), 5);
+        assert_eq!(deep.members.len(), 6);
         assert_eq!(deep.members[0], "claude:opus@xhigh");
+        assert_eq!(deep.members[5], "grok:grok-4.5@high");
     }
 
     #[test]

--- a/crates/caucus-cli/src/commands/review.rs
+++ b/crates/caucus-cli/src/commands/review.rs
@@ -2314,6 +2314,7 @@ mod tests {
                 "codex:default@xhigh",
                 "opencode:zai-coding-plan/glm-5.2@xhigh",
                 "kimi:kimi-code/k3@high",
+                "grok:grok-4.5@high",
             ]
         );
     }

--- a/crates/caucus-core/src/config.rs
+++ b/crates/caucus-core/src/config.rs
@@ -106,6 +106,7 @@ members = [
     "codex:default@xhigh",
     "opencode:zai-coding-plan/glm-5.2@xhigh",
     "kimi:kimi-code/k3@high",
+    "grok:grok-4.5@high",
 ]
 "#;
 
@@ -464,6 +465,7 @@ members = ["codex:default@xhigh", "kimi:kimi-code/k3@high"]
                 "codex:default@xhigh",
                 "opencode:zai-coding-plan/glm-5.2@xhigh",
                 "kimi:kimi-code/k3@high",
+                "grok:grok-4.5@high",
             ]
         );
         assert_eq!(council.strategy, "judge");

--- a/crates/caucus-core/tests/provider_profile_test.rs
+++ b/crates/caucus-core/tests/provider_profile_test.rs
@@ -30,6 +30,7 @@ fn deep_council_members_and_metadata_are_exact() {
             "codex:default@xhigh",
             "opencode:zai-coding-plan/glm-5.2@xhigh",
             "kimi:kimi-code/k3@high",
+            "grok:grok-4.5@high",
         ]
     );
 
@@ -303,7 +304,7 @@ fn config_example_parses_and_named_profiles_resolve() {
     // The example's default profile resolves to the built-in deep council.
     let council = config.resolve_profile(None).unwrap();
     assert_eq!(council.name, "deep");
-    assert_eq!(council.members.len(), 5);
+    assert_eq!(council.members.len(), 6);
 
     // User-defined named profiles resolve too.
     let frontier = config.resolve_profile(Some("frontier")).unwrap();

--- a/examples/caucus.toml
+++ b/examples/caucus.toml
@@ -35,6 +35,7 @@ model = "llama3.2:latest"
 #   codex:default@xhigh                     (stable adapter)
 #   opencode:zai-coding-plan/glm-5.2@xhigh  (experimental adapter)
 #   kimi:kimi-code/k3@high                  (experimental adapter)
+#   grok:grok-4.5@high                      (experimental adapter)
 
 # A local-only profile; no API keys required.
 [profiles.local]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -14,7 +14,8 @@
 
 # Default profile. The built-in `deep` profile has exactly these members:
 #   claude:opus@xhigh, claude:claude-fable-5@xhigh, codex:default@xhigh,
-#   opencode:zai-coding-plan/glm-5.2@xhigh, kimi:kimi-code/k3@high
+#   opencode:zai-coding-plan/glm-5.2@xhigh, kimi:kimi-code/k3@high,
+#   grok:grok-4.5@high
 # User profiles defined below shadow built-ins.
 default_profile = "deep"
 


### PR DESCRIPTION
## What changed

- render `caucus doctor` as Markdown tables for config, warnings, adapters, profiles, and summary
- keep `doctor --json` unchanged
- move doctor migration warnings into the structured report instead of unformatted stderr
- add `grok:grok-4.5@high` to the built-in `deep` profile
- update profile documentation and exact-member tests

## Why

Doctor output is easier to scan in a terminal and can be pasted directly into Markdown issues or reviews. The deep council now also includes the installed Grok Build subscription CLI.

## Validation

- `cargo test --workspace --all-targets --quiet` (190 tests)
- `cargo test --doc --workspace --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- real `caucus doctor` run against both modern and legacy configs